### PR TITLE
Make vstyle discovery language-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ vstyle coverage
 # Workspace-wide.
 vstyle curate --workspace
 
+# Swift workspace-wide.
+vstyle curate --workspace --language swift
+
 # Selected packages.
 vstyle tune -p api -p db-service
 
@@ -167,14 +170,17 @@ vstyle tune -p api --all-features --no-default-features
   - Exit `0`: even if unresolved violations remain.
   - Exit `1`: unresolved violations remain and `--strict` is used.
 
-By default, `curate` and `tune` follow cargo default package selection and scan git-tracked `*.rs`
-and `*.swift` files inside that package scope. With `--workspace`, Rust files are selected from
-workspace package roots and Swift files are selected from the Cargo workspace root.
+By default, `curate` and `tune` check Rust files. Use `--language swift` to check Swift files.
+File discovery scans every selected `*.rs` or `*.swift` file that is not matched by Git ignore
+rules inside that package scope. Git tracking state is not part of file discovery. With
+`--workspace`, Rust files are selected from workspace package roots and Swift files are selected
+from the Cargo workspace root.
 
 ### CI policy
 
-CI runs `vstyle curate` (read-only verification) to keep feedback fast and deterministic.
-Use `vstyle tune` locally when you want to apply safe automatic fixes (for example, via `cargo make lint-fix`).
+CI runs language-specific `vstyle curate` commands (read-only verification) to keep feedback fast
+and deterministic. Use `vstyle tune` locally when you want to apply safe automatic fixes (for
+example, via `cargo make lint-fix`).
 
 ### Release benchmark
 
@@ -190,7 +196,7 @@ cargo make bench-release-vstyle
 By default the harness builds the shipping `final-release` profile from `Cargo.toml` and runs both
 `vstyle curate --workspace` and `vstyle tune --workspace --verbose` inside a disposable Git
 worktree at the current commit. This keeps `tune` from rewriting the primary checkout while still
-preserving `git ls-files` semantics for file discovery.
+preserving the Git ignore boundary used for file discovery.
 
 Treat the checked-in self-host benchmark as a release-path regression guard, not as a universal
 microbenchmark for every hotspot. On the current workspace it is usually a no-op `tune`; if
@@ -220,7 +226,7 @@ validation fallback behavior:
 cargo make bench-semantic-vstyle
 ```
 
-This harness builds the local release binary once, creates a disposable Git-tracked fixture crate
+This harness builds the local release binary once, creates a disposable Git fixture crate
 based on the `tests/let_mut_reorder.rs` semantic-validation shape, generates a local `Cargo.lock`,
 and runs `vstyle tune --verbose` twice:
 
@@ -271,7 +277,7 @@ Rules are built into the checker.
   - `rustc -Vv` output,
   - `Cargo.lock` hash,
   - selected cargo options,
-  - tracked `*.rs` file fingerprints.
+  - selected `*.rs` style file fingerprints.
 
 ## Rule Catalog
 

--- a/docs/plans/2026-03-11_vstyle-release-runtime-acceleration.md
+++ b/docs/plans/2026-03-11_vstyle-release-runtime-acceleration.md
@@ -20,7 +20,7 @@ Improve the final release-binary runtime of `vstyle curate --workspace` and `vst
 
 - Acceptance is based on release-binary runtime only. Debug timings are diagnostic only.
 - `Makefile.toml` is the source of truth for existing repo tasks, but direct release-binary commands are required for performance acceptance because `cargo make lint-vstyle` routes through `cargo vstyle curate --workspace`.
-- `vstyle` file discovery depends on `git ls-files` in `src/style/shared.rs`, so benchmarks must run inside a real Git checkout rather than a plain copied directory.
+- `vstyle` file discovery depends on Git ignore evaluation in `src/style/shared.rs`, so benchmarks must run inside a real Git checkout rather than a plain copied directory.
 - `vstyle tune` mutates files; all release benchmarking for `tune` should run in a disposable Git worktree or equivalent isolated checkout.
 - Execution should start from a clean `main` worktree and follow the isolated-workspace flow before code changes begin.
 
@@ -38,7 +38,7 @@ Improve the final release-binary runtime of `vstyle curate --workspace` and `vst
 ## Decision Notes
 
 - Acceptance and closeout for this stream are release-binary only. Debug-path measurements remain useful for hotspot discovery but do not count as success criteria.
-- The benchmark harness should use a disposable Git worktree at the current commit because `src/style/shared.rs` resolves files through `git ls-files` and `tune` can rewrite tracked files.
+- The benchmark harness should use a disposable Git worktree at the current commit because `src/style/shared.rs` resolves files through Git ignore evaluation and `tune` can rewrite style files.
 - Performance verification should call the locally built release binary directly (`target/release/vstyle` or the selected final shipping profile), not `cargo make lint-vstyle`, to avoid accidentally benchmarking an installed `cargo-vstyle` binary outside the repo build.
 - 2026-03-12: Task 1 defaulted benchmark acceptance to `final-release`, with `release` retained as a diagnostic override and compatibility check.
 - 2026-03-12: Current live runtime executes directly with optional read-only sidecars; Task 1 resumed in the existing isolated worktree after stale Builder-only routing proved inapplicable to the live environment.
@@ -46,12 +46,12 @@ Improve the final release-binary runtime of `vstyle curate --workspace` and `vst
 - 2026-03-12: Task 3 replaced intermediate full-workspace rechecks with incremental per-file refreshes plus a final full pass. On this host, repeated `final-release` reruns dropped `tune` from the `4.35s` baseline to `2.89s`, `2.93s`, and `2.87s`, so the fix engine checkpoint is materially successful and Task 4 is now the next runtime target.
 - 2026-03-12: Task 4 collapsed repeated import-rule analysis into shared per-file state across import rules and cfg-test follow-up scans. On this host, `final-release` reruns landed at `2.98s`, `2.88s`, and `2.92s` tune, which stays inside the prior `2.87s` to `2.93s` band, so the checkpoint is structurally complete but runtime-neutral and Task 5 is now the next target.
 - 2026-03-12: Task 5 module/quality scan-fusion and regex-hoist experiments were benchmarked but not retained. The reverted fresh baseline measured `2.99s` tune, and the exploratory runs stayed in the `2.95s` to `3.07s` range, so that checkpoint remains queued rather than landed.
-- 2026-03-12: Fresh no-op release benchmarks still do not enter semantic validation (`Semantic cache: 0 hit(s), 0 miss(es)`), so Task 6 narrowed to discovery-path reuse only. Caching workspace metadata and tracked-file discovery, then reusing grouped package scopes, moved `final-release tune` to `2.84s`, `2.93s`, `2.93s`, and `2.95s` versus the fresh post-revert `2.99s` baseline, which is a modest improvement without justifying semantic-path work yet.
+- 2026-03-12: Fresh no-op release benchmarks still do not enter semantic validation (`Semantic cache: 0 hit(s), 0 miss(es)`), so Task 6 narrowed to discovery-path reuse only. Caching workspace metadata and style-file discovery, then reusing grouped package scopes, moved `final-release tune` to `2.84s`, `2.93s`, `2.93s`, and `2.95s` versus the fresh post-revert `2.99s` baseline, which is a modest improvement without justifying semantic-path work yet.
 - 2026-03-12: Task 7 closed the current execution wave. README guidance now explains how to interpret the self-host no-op benchmark versus semantic-path workloads, the benchmark doc records the before/after release history, `XY-92` is done, and `XY-95`/`XY-97` remain queued as measured follow-ups.
 
 ## Implementation Outline
 
-Start with `XY-91` and make performance measurement reproducible before touching optimizer code. The harness should build the local release binary once, create a disposable Git worktree anchored to the current commit, run `curate` and `tune` against that isolated checkout, and record enough metadata to keep cache state, profile choice, and commit identity explicit. This protects the main checkout from `tune` rewrites while keeping `git ls-files` semantics intact for `vstyle`.
+Start with `XY-91` and make performance measurement reproducible before touching optimizer code. The harness should build the local release binary once, create a disposable Git worktree anchored to the current commit, run `curate` and `tune` against that isolated checkout, and record enough metadata to keep cache state, profile choice, and commit identity explicit. This protects the main checkout from `tune` rewrites while keeping the Git ignore boundary intact for `vstyle`.
 
 Once the release benchmark exists, attack the highest-confidence runtime multipliers in `src/style.rs` first. Current code shows that `run_fix` triggers an initial `run_check`, then re-runs `run_check` after each tune round, while `collect_fix_outcomes` and `apply_fix_passes` repeatedly read, clone, parse, and sometimes precompute fallback variants even before semantic validation proves they are necessary. These are the first checkpoints because they affect the no-op `tune` path before semantic work dominates.
 
@@ -271,7 +271,7 @@ Release-benchmark evidence showed that the current no-op `tune` workload still b
 
 1. Use fresh post-Task-5 release benchmarks to determine whether semantic validation or discovery work still contributes enough runtime to justify immediate action.
 2. Keep semantic-path work queued when the benchmark does not enter semantic validation, instead of broadening the checkpoint without evidence.
-3. Land a narrow discovery-path reuse checkpoint by caching workspace metadata and tracked-file discovery, then grouping workspace files by package directly instead of rediscovering each package scope separately.
+3. Land a narrow discovery-path reuse checkpoint by caching workspace metadata and style-file discovery, then grouping workspace files by package directly instead of rediscovering each package scope separately.
 
 **Verification**
 

--- a/docs/plans/2026-03-12_vstyle-semantic-runtime-follow-up.md
+++ b/docs/plans/2026-03-12_vstyle-semantic-runtime-follow-up.md
@@ -26,8 +26,8 @@ the change.
 
 - Acceptance for this lane is still based on the locally built `final-release` binary, not an
   installed `cargo-vstyle` subcommand and not debug/profile-development timings.
-- `vstyle` file discovery still depends on `git ls-files`, so the benchmark workload must run inside
-  a real Git checkout.
+- `vstyle` file discovery still depends on Git ignore evaluation, so the benchmark workload must
+  run inside a real Git checkout.
 - `vstyle tune` mutates files; semantic benchmarking must use a disposable fixture checkout and keep
   the main worktree untouched.
 - A meaningful `XY-95` checkpoint must preserve semantic-validation behavior and cache semantics; it

--- a/docs/research/benchmarks/2026-03-12_vstyle-release-runtime-baseline.md
+++ b/docs/research/benchmarks/2026-03-12_vstyle-release-runtime-baseline.md
@@ -186,7 +186,7 @@ continuing, and the post-revert rerun became the fresh baseline for Task 6.
 Task 6 stayed evidence-gated. The current self-host benchmark is still a no-op `tune`
 (`Checked 21 file(s). Applied 0 fix(es). Semantic cache: 0 hit(s), 0 miss(es).`), so semantic
 follow-ups remain queued. The landed checkpoint only targets discovery-path reuse by caching
-workspace metadata and tracked-file discovery, then grouping workspace files into per-package
+workspace metadata and style-file discovery, then grouping workspace files into per-package
 scopes directly instead of rediscovering each package scope separately.
 
 On this host, that narrowed checkpoint moved `final-release tune` from the fresh `2.99s`

--- a/docs/research/benchmarks/2026-03-12_vstyle-semantic-runtime-baseline.md
+++ b/docs/research/benchmarks/2026-03-12_vstyle-semantic-runtime-baseline.md
@@ -8,7 +8,7 @@ semantic-positive benchmark run from the checked-in harness.
 ## Workload
 
 - Fixture source: `tests/let_mut_reorder.rs`
-- Workload shape: a disposable Git-tracked Cargo crate with one semantically safe `let mut`
+- Workload shape: a disposable Git fixture Cargo crate with one semantically safe `let mut`
   reorder candidate and one unsafe closure-capture case that must remain unchanged.
 - Cold run policy: clear `target/vstyle-cache/semantic` before the first `tune --verbose` run.
 - Warm run policy: restore the original fixture sources and rerun without clearing the cache.
@@ -48,7 +48,7 @@ semantic-positive benchmark run from the checked-in harness.
   should distinguish repeated semantic `cargo check` work from cache-key overhead rather than treat
   semantic validation as purely uncached.
 - The warm rerun drops to `0.15s` with `3` hits and `0` misses after restoring the original source
-  texts, which proves the current semantic cache is reusable across invocations when tracked-file
+  texts, which proves the current semantic cache is reusable across invocations when style-file
   fingerprints return to the same state.
 - This checkpoint only adds the benchmark harness and docs, so the binary version string still
   reflects the last Rust-code build metadata refresh. Use the benchmark workload commit and log

--- a/docs/runbook/benchmark_tracking.md
+++ b/docs/runbook/benchmark_tracking.md
@@ -35,6 +35,8 @@ Verification:
 ## Pre-commit local evidence
 
 - Build the current shipping binary with `cargo build --profile final-release --bins`.
+- File discovery follows Git ignore rules only: every non-ignored style file for the selected
+  language is scanned, and tracking state does not affect local discovery.
 - If the change expands self-host style coverage, run
   `target/final-release/vstyle curate --workspace` first and fix any newly reported repository drift
   before treating timing results as meaningful.
@@ -47,6 +49,9 @@ Verification:
 
 - `cargo make bench-release-vstyle` builds the current binary but runs the workload inside a
   detached Git worktree at `HEAD`.
+- The detached workload does not include uncommitted files from the primary checkout, even though
+  direct local `vstyle` runs include every selected-language, non-ignored style file in the current
+  working tree.
 - If the current working tree contains uncommitted self-host rewrites, the harness can still fail
   on the detached workload even after the local working tree is clean.
 - Use this harness as the authoritative release-path benchmark only after the relevant source

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use clap::{
-	Args, Parser, Subcommand,
+	Args, Parser, Subcommand, ValueEnum,
 	builder::{
 		Styles,
 		styling::{AnsiColor, Effects},
@@ -12,7 +12,7 @@ use clap::{
 };
 use color_eyre::Result;
 
-use crate::style::{self, CargoOptions, RunSummary};
+use crate::style::{self, CargoOptions, RunSummary, StyleLanguage};
 
 /// Command-line interface for the style checker.
 #[derive(Debug, Parser)]
@@ -109,6 +109,9 @@ enum Command {
 
 #[derive(Clone, Debug, Args)]
 struct CargoCliOptions {
+	/// Source language to check.
+	#[arg(long = "language", value_enum, default_value_t = LanguageCliOption::Rust)]
+	language: LanguageCliOption,
 	/// Check all packages in the workspace.
 	#[arg(long)]
 	workspace: bool,
@@ -128,11 +131,26 @@ struct CargoCliOptions {
 impl CargoCliOptions {
 	fn as_options(&self) -> CargoOptions {
 		CargoOptions {
+			language: self.language.into(),
 			workspace: self.workspace,
 			packages: self.packages.clone(),
 			features: self.features.clone(),
 			all_features: self.all_features,
 			no_default_features: self.no_default_features,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum LanguageCliOption {
+	Rust,
+	Swift,
+}
+impl From<LanguageCliOption> for StyleLanguage {
+	fn from(value: LanguageCliOption) -> Self {
+		match value {
+			LanguageCliOption::Rust => Self::Rust,
+			LanguageCliOption::Swift => Self::Swift,
 		}
 	}
 }
@@ -177,7 +195,10 @@ fn styles() -> Styles {
 mod tests {
 	use clap::Parser;
 
-	use crate::cli::{Cli, Command};
+	use crate::{
+		cli::{Cli, Command, LanguageCliOption},
+		style::StyleLanguage,
+	};
 
 	#[test]
 	fn parses_curate_subcommand() {
@@ -225,10 +246,23 @@ mod tests {
 		};
 
 		assert!(cargo.workspace);
+		assert_eq!(cargo.language, LanguageCliOption::Rust);
 		assert_eq!(cargo.packages, vec!["api"]);
 		assert_eq!(cargo.features, vec!["serde", "tracing"]);
 		assert!(cargo.all_features);
 		assert!(cargo.no_default_features);
+	}
+
+	#[test]
+	fn parses_curate_with_swift_language() {
+		let cli = Cli::parse_from(["app", "curate", "--workspace", "--language", "swift"]);
+		let Command::Curate { cargo, .. } = cli.command else {
+			panic!("Expected curate command.");
+		};
+
+		assert!(cargo.workspace);
+		assert_eq!(cargo.language, LanguageCliOption::Swift);
+		assert_eq!(StyleLanguage::from(cargo.language), StyleLanguage::Swift);
 	}
 
 	#[test]

--- a/src/style.rs
+++ b/src/style.rs
@@ -13,7 +13,7 @@ mod swift;
 mod test_modules;
 mod types;
 
-pub(crate) use shared::{CargoOptions, RunSummary};
+pub(crate) use shared::{CargoOptions, RunSummary, StyleLanguage};
 
 use std::{
 	collections::{BTreeMap, BTreeSet},

--- a/src/style/semantic.rs
+++ b/src/style/semantic.rs
@@ -46,7 +46,7 @@ pub(crate) fn apply_semantic_fixes(
 		return Ok(0);
 	}
 
-	let tracked = files.iter().map(|path| normalize_path(path)).collect::<BTreeSet<_>>();
+	let style_files = files.iter().map(|path| normalize_path(path)).collect::<BTreeSet<_>>();
 	let mut applied_total = 0_usize;
 	let mut next_stdout = initial_stdout;
 
@@ -59,7 +59,7 @@ pub(crate) fn apply_semantic_fixes(
 		let mut applied_round = 0_usize;
 
 		for (path, imports) in suggestions {
-			if !tracked.contains(&path) {
+			if !style_files.contains(&path) {
 				continue;
 			}
 
@@ -86,11 +86,11 @@ pub(crate) fn collect_compiler_error_files_with_output(
 		return Ok((String::new(), BTreeSet::new()));
 	}
 
-	let tracked = files.iter().map(|path| normalize_path(path)).collect::<BTreeSet<_>>();
+	let style_files = files.iter().map(|path| normalize_path(path)).collect::<BTreeSet<_>>();
 	let stdout = run_semantic_cargo_check(cargo_options, files, verbose, progress)?;
 	let all = collect_compiler_error_files_from_output(&stdout);
 	let compiler_error_files =
-		all.into_iter().filter(|path| tracked.contains(path)).collect::<BTreeSet<_>>();
+		all.into_iter().filter(|path| style_files.contains(path)).collect::<BTreeSet<_>>();
 
 	Ok((stdout, compiler_error_files))
 }
@@ -283,13 +283,13 @@ fn semantic_cache_key(
 	input.push_str("cargo_args=");
 	input.push_str(&args.join(" "));
 	input.push('\n');
-	input.push_str("tracked_files=");
+	input.push_str("style_files=");
 
-	let mut tracked_files = files.to_vec();
+	let mut style_files = files.to_vec();
 
-	tracked_files.sort();
+	style_files.sort();
 
-	for file in tracked_files {
+	for file in style_files {
 		let fingerprint = file_fingerprint(&file, verbose)?;
 
 		input.push('\n');
@@ -379,13 +379,13 @@ fn file_fingerprint(path: &Path, verbose: bool) -> Result<(PathBuf, String)> {
 			log_verbose_error(
 				verbose,
 				&format!(
-					"Failed to read tracked file '{}' for cache fingerprint: {err}.",
+					"Failed to read style file '{}' for cache fingerprint: {err}.",
 					absolute.display()
 				),
 			);
 
 			return Err(eyre::eyre!(
-				"Failed to read tracked file '{}' for cache fingerprint: {err}.",
+				"Failed to read style file '{}' for cache fingerprint: {err}.",
 				absolute.display()
 			));
 		},

--- a/src/style/shared.rs
+++ b/src/style/shared.rs
@@ -1,8 +1,9 @@
 use std::{
 	collections::{BTreeMap, HashSet},
 	env, fs,
+	io::Write as _,
 	path::{Path, PathBuf},
-	process::Command,
+	process::{Command, Stdio},
 	sync::{LazyLock, Mutex},
 };
 
@@ -13,6 +14,9 @@ use ra_ap_syntax::{
 	ast::{self, HasAttrs, HasModuleItem, HasName, HasVisibility, Item},
 };
 use regex::Regex;
+
+type StyleFilesCacheKey = (PathBuf, PathBuf);
+type StyleFilesCache = BTreeMap<StyleFilesCacheKey, Vec<PathBuf>>;
 
 pub(crate) const STYLE_RULE_IDS: [&str; 43] = [
 	"RUST-STYLE-FILE-001",
@@ -95,7 +99,7 @@ pub(crate) static WORKSPACE_IMPORT_ROOTS: LazyLock<HashSet<String>> = LazyLock::
 	roots
 });
 
-static GIT_STYLE_FILES_CACHE: LazyLock<Mutex<BTreeMap<PathBuf, Vec<PathBuf>>>> =
+static STYLE_FILES_CACHE: LazyLock<Mutex<StyleFilesCache>> =
 	LazyLock::new(|| Mutex::new(BTreeMap::new()));
 static WORKSPACE_LAYOUT_CACHE: LazyLock<Mutex<BTreeMap<PathBuf, WorkspaceLayout>>> =
 	LazyLock::new(|| Mutex::new(BTreeMap::new()));
@@ -140,11 +144,19 @@ pub(crate) struct RunSummary {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CargoOptions {
+	pub(crate) language: StyleLanguage,
 	pub(crate) workspace: bool,
 	pub(crate) packages: Vec<String>,
 	pub(crate) features: Vec<String>,
 	pub(crate) all_features: bool,
 	pub(crate) no_default_features: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum StyleLanguage {
+	#[default]
+	Rust,
+	Swift,
 }
 
 #[derive(Clone, Debug)]
@@ -224,22 +236,31 @@ pub(crate) fn push_violation(
 }
 
 pub(crate) fn resolve_files(cargo_options: &CargoOptions) -> Result<Vec<PathBuf>> {
-	let git_files = git_ls_files_style_sources()?;
 	let workspace_layout = workspace_layout()?;
 	let mut selected_rust_roots = HashSet::new();
 	let mut selected_swift_roots = HashSet::new();
 
 	if cargo_options.workspace {
-		for package in &workspace_layout.workspace_packages {
-			selected_rust_roots.insert(package.root.clone());
+		match cargo_options.language {
+			StyleLanguage::Rust =>
+				for package in &workspace_layout.workspace_packages {
+					selected_rust_roots.insert(package.root.clone());
+				},
+			StyleLanguage::Swift => {
+				selected_swift_roots.insert(workspace_layout.workspace_root.clone());
+			},
 		}
-
-		selected_swift_roots.insert(workspace_layout.workspace_root.clone());
 	}
 	if !cargo_options.workspace && cargo_options.packages.is_empty() {
 		for root in &workspace_layout.default_roots {
-			selected_rust_roots.insert(root.clone());
-			selected_swift_roots.insert(root.clone());
+			match cargo_options.language {
+				StyleLanguage::Rust => {
+					selected_rust_roots.insert(root.clone());
+				},
+				StyleLanguage::Swift => {
+					selected_swift_roots.insert(root.clone());
+				},
+			}
 		}
 	}
 	if !cargo_options.packages.is_empty() {
@@ -261,8 +282,14 @@ pub(crate) fn resolve_files(cargo_options: &CargoOptions) -> Result<Vec<PathBuf>
 			}
 
 			if matched {
-				selected_rust_roots.insert(package.root.clone());
-				selected_swift_roots.insert(package.root.clone());
+				match cargo_options.language {
+					StyleLanguage::Rust => {
+						selected_rust_roots.insert(package.root.clone());
+					},
+					StyleLanguage::Swift => {
+						selected_swift_roots.insert(package.root.clone());
+					},
+				}
 			}
 		}
 
@@ -282,9 +309,10 @@ pub(crate) fn resolve_files(cargo_options: &CargoOptions) -> Result<Vec<PathBuf>
 	}
 
 	let cwd = current_dir_normalized()?;
+	let style_files = gitignore_visible_style_sources(&workspace_layout.workspace_root)?;
 	let mut files = Vec::new();
 
-	for relative in git_files {
+	for relative in style_files {
 		let absolute = normalize_path(&cwd.join(&relative));
 		let selected_roots =
 			if is_swift_file(&relative) { &selected_swift_roots } else { &selected_rust_roots };
@@ -522,36 +550,133 @@ fn collect_package_rust_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()
 	Ok(())
 }
 
-fn git_ls_files_style_sources() -> Result<Vec<PathBuf>> {
+fn gitignore_visible_style_sources(workspace_root: &Path) -> Result<Vec<PathBuf>> {
 	let cwd = current_dir_normalized()?;
+	let workspace_root = normalize_path(workspace_root);
+	let cache_key = (cwd.clone(), workspace_root.clone());
 
 	if let Some(files) =
-		GIT_STYLE_FILES_CACHE.lock().expect("Lock git ls-files cache.").get(&cwd).cloned()
+		STYLE_FILES_CACHE.lock().expect("Lock style files cache.").get(&cache_key).cloned()
 	{
 		return Ok(files);
 	}
 
-	let output = Command::new("git")
-		.args(["ls-files", "*.rs", "*.swift"])
-		.output()
-		.map_err(|err| eyre::eyre!("Failed to run git ls-files: {err}."))?;
-
-	if !output.status.success() {
-		return Err(eyre::eyre!("git ls-files failed with status {}.", output.status));
-	}
-
-	let stdout = String::from_utf8(output.stdout)?;
 	let mut files = Vec::new();
 
-	for line in stdout.lines() {
-		if !line.is_empty() {
-			files.push(PathBuf::from(line));
+	collect_gitignore_visible_style_sources(&workspace_root, &cwd, &mut files)?;
+
+	files.sort();
+	files.dedup();
+	STYLE_FILES_CACHE.lock().expect("Lock style files cache.").insert(cache_key, files.clone());
+
+	Ok(files)
+}
+
+fn collect_gitignore_visible_style_sources(
+	dir: &Path,
+	cwd: &Path,
+	files: &mut Vec<PathBuf>,
+) -> Result<()> {
+	let entries = fs::read_dir(dir)
+		.map_err(|err| eyre::eyre!("Failed to read style directory `{}`: {err}.", dir.display()))?;
+	let mut entries = entries
+		.map(|entry| {
+			let entry =
+				entry.map_err(|err| eyre::eyre!("Failed to read style directory entry: {err}."))?;
+			let path = entry.path();
+			let file_type = entry.file_type().map_err(|err| {
+				eyre::eyre!("Failed to read file type for style path `{}`: {err}.", path.display())
+			})?;
+
+			Ok((path, file_type, entry.file_name()))
+		})
+		.collect::<Result<Vec<_>>>()?;
+
+	entries.sort_by(|left, right| left.0.cmp(&right.0));
+
+	let ignored = gitignored_paths(entries.iter().map(|(path, _, _)| path.as_path()), cwd)?;
+
+	for (path, file_type, name) in entries {
+		let relative = path_for_cwd(&path, cwd);
+		let is_ignored = ignored.contains(&relative);
+		let name = name.to_string_lossy();
+
+		if file_type.is_dir() {
+			if name == ".git" || is_ignored {
+				continue;
+			}
+
+			collect_gitignore_visible_style_sources(&path, cwd, files)?;
+
+			continue;
+		}
+		if file_type.is_file() && is_style_source_file(&path) && !is_ignored {
+			files.push(relative);
 		}
 	}
 
-	GIT_STYLE_FILES_CACHE.lock().expect("Lock git ls-files cache.").insert(cwd, files.clone());
+	Ok(())
+}
 
-	Ok(files)
+fn gitignored_paths<'a>(
+	paths: impl IntoIterator<Item = &'a Path>,
+	cwd: &Path,
+) -> Result<HashSet<PathBuf>> {
+	let paths = paths.into_iter().map(|path| path_for_cwd(path, cwd)).collect::<Vec<_>>();
+
+	if paths.is_empty() {
+		return Ok(HashSet::new());
+	}
+
+	let mut child = Command::new("git")
+		.current_dir(cwd)
+		.args(["check-ignore", "--no-index", "--stdin"])
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.spawn()
+		.map_err(|err| eyre::eyre!("Failed to run git check-ignore: {err}."))?;
+
+	{
+		let mut stdin = child
+			.stdin
+			.take()
+			.ok_or_else(|| eyre::eyre!("Failed to open git check-ignore stdin."))?;
+
+		for path in &paths {
+			writeln!(stdin, "{}", path.display())
+				.map_err(|err| eyre::eyre!("Failed to write git check-ignore input: {err}."))?;
+		}
+	}
+
+	let output = child
+		.wait_with_output()
+		.map_err(|err| eyre::eyre!("Failed to wait for git check-ignore: {err}."))?;
+
+	match output.status.code() {
+		Some(0) | Some(1) => {},
+		_ => return Err(eyre::eyre!("git check-ignore failed with status {}.", output.status)),
+	}
+
+	let stdout = String::from_utf8(output.stdout)?;
+	let mut ignored = HashSet::new();
+
+	for line in stdout.lines() {
+		if !line.is_empty() {
+			ignored.insert(PathBuf::from(line));
+		}
+	}
+
+	Ok(ignored)
+}
+
+fn is_style_source_file(path: &Path) -> bool {
+	matches!(path.extension().and_then(|ext| ext.to_str()), Some("rs" | "swift"))
+}
+
+fn path_for_cwd(path: &Path, cwd: &Path) -> PathBuf {
+	let normalized = normalize_path(path);
+
+	normalized.strip_prefix(cwd).map_or(normalized.clone(), Path::to_path_buf)
 }
 
 fn workspace_layout() -> Result<WorkspaceLayout> {

--- a/tests/swift_curate.rs
+++ b/tests/swift_curate.rs
@@ -35,13 +35,17 @@ edition = "2021"
 	)
 	.expect("Write package manifest.");
 	fs::write(root.join("crates/app/src/lib.rs"), "").expect("Write Rust lib.");
-	fs::write(root.join(".gitignore"), "/target\n").expect("Write gitignore.");
+	fs::write(
+		root.join(".gitignore"),
+		"/target\n/Sources/App/Ignored.swift\n/Sources/App/IgnoredTracked.swift\n",
+	)
+	.expect("Write gitignore.");
 
 	root
 }
 
 #[test]
-fn curate_reports_swift_workspace_violations_from_tracked_files() {
+fn curate_reports_swift_workspace_violations_from_non_ignored_files() {
 	let temp_dir = create_temp_workspace_root();
 	let long_body = (0..121).map(|idx| format!("\tlet value{idx} = {idx}\n")).collect::<String>();
 	let swift_source = format!(
@@ -68,6 +72,10 @@ func testForceAllowed() {
 	fs::write(temp_dir.join("Sources/App/mod.swift"), swift_source).expect("write Swift source");
 	fs::write(temp_dir.join("Sources/App/Untracked.swift"), "let value = missing!\n")
 		.expect("write untracked Swift source");
+	fs::write(temp_dir.join("Sources/App/Ignored.swift"), "let value = ignored!\n")
+		.expect("write ignored Swift source");
+	fs::write(temp_dir.join("Sources/App/IgnoredTracked.swift"), "let value = trackedIgnored!\n")
+		.expect("write tracked ignored Swift source");
 	fs::write(temp_dir.join("Tests/AppTests.swift"), swift_test_source)
 		.expect("write Swift test source");
 
@@ -84,9 +92,11 @@ func testForceAllowed() {
 		.current_dir(&temp_dir)
 		.args([
 			"add",
+			"-f",
 			"Cargo.toml",
 			"crates/app/Cargo.toml",
 			"crates/app/src/lib.rs",
+			"Sources/App/IgnoredTracked.swift",
 			"Sources/App/mod.swift",
 			"Tests/AppTests.swift",
 		])
@@ -102,6 +112,25 @@ func testForceAllowed() {
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
 		.args(["curate", "--workspace"])
+		.output()
+		.expect("run vstyle");
+
+	assert!(
+		output.status.success(),
+		"default Rust-only curate should ignore Swift violations, stderr: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let stdout = String::from_utf8_lossy(&output.stdout);
+
+	assert!(
+		!stdout.contains("Sources/App/mod.swift"),
+		"default Rust-only curate should not scan Swift files:\n{stdout}"
+	);
+
+	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
+		.current_dir(&temp_dir)
+		.args(["curate", "--workspace", "--language", "swift"])
 		.output()
 		.expect("run vstyle");
 
@@ -124,5 +153,13 @@ func testForceAllowed() {
 		!stdout.contains("Tests/AppTests.swift:2:1: [SWIFT-STYLE-RUNTIME-001]"),
 		"Swift test files should not report force operators:\n{stdout}"
 	);
-	assert!(!stdout.contains("Untracked.swift"), "untracked Swift files should not be scanned");
+	assert!(
+		stdout.contains("Untracked.swift"),
+		"non-ignored Swift files should be scanned regardless of tracking state"
+	);
+	assert!(!stdout.contains("Ignored.swift"), "git-ignored Swift files should not be scanned");
+	assert!(
+		!stdout.contains("IgnoredTracked.swift"),
+		"git-ignored Swift files should not be scanned even when tracked"
+	);
 }


### PR DESCRIPTION
Summary:
- Default workspace discovery to Rust files and add explicit `--language swift` selection.
- Discover candidate files from the filesystem and filter only through Git ignore rules, independent of tracking state.
- Update Swift regression coverage and docs so Rust and Swift usage are configured separately.

Validation:
- `cargo test --bin vstyle parses_curate_with_swift_language`
- `cargo test --test swift_curate curate_reports_swift_workspace_violations_from_non_ignored_files`
- `cargo run --bin vstyle -- curate --workspace --all-features`
- `cargo run --bin vstyle -- curate --workspace --language swift`
- `cargo +nightly fmt --all -- --check`
- `cargo make fmt-check`
- `cargo make lint-rust`
- `cargo make test-rust`
- `git diff --check`
- semantic drift audit passed