### PR TITLE
Release vibe-style 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,15 +97,14 @@ jobs:
           mkdir -p artifacts
           mv vibe-style-*/* artifacts/
           cd artifacts
-          sha256sum * | tee ../SHA256
-          md5sum * | tee ../MD5
+          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum | tee ../SHA256
+          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 md5sum | tee ../MD5
           mv ../SHA256 .
           mv ../MD5 .
 
       - name: Publish
         uses: softprops/action-gh-release@v2
         with:
-          discussion_category_name: Announcements
           generate_release_notes: true
           files: artifacts/*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-style"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name        = "vibe-style"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/vibe-style"
 resolver    = "3"
-version     = "0.1.18"
+version     = "0.2.0"
 
 [[bin]]
 name = "vstyle"


### PR DESCRIPTION
Summary:
- Bump `vibe-style` from 0.1.18 to 0.2.0 in Cargo.toml and Cargo.lock.
- Remove the invalid release discussion category that broke the v0.1.18 release finalization.
- Hash only release artifact files in release.yml so artifact directories do not produce checksum noise.

Validation:
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `cargo metadata --locked --no-deps --format-version 1` reports 0.2.0
- `cargo make checks`
- `cargo build --profile final-release --bins --locked`
- `cargo publish --dry-run --locked --allow-dirty` before commit
- `cargo publish --dry-run --locked` after commit