### PR TITLE
Require explicit vstyle language

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,14 +1,17 @@
 # Rust workspace tasks.
 
 # Lint
-# | task            | type      | cwd |
-# | --------------- | --------- | --- |
-# | lint            | composite |     |
-# | lint-fix        | composite |     |
-# | lint-rust       | command   |     |
-# | lint-fix-rust   | extend    |     |
-# | lint-vstyle     | command   |     |
-# | lint-fix-vstyle | command   |     |
+# | task                 | type      | cwd |
+# | -------------------- | --------- | --- |
+# | lint                 | composite |     |
+# | lint-fix             | composite |     |
+# | lint-rust            | command   |     |
+# | lint-fix-rust        | extend    |     |
+# | lint-vstyle          | composite |     |
+# | lint-vstyle-rust     | command   |     |
+# | lint-vstyle-swift    | command   |     |
+# | lint-fix-vstyle      | composite |     |
+# | lint-fix-vstyle-rust | command   |     |
 
 [tasks.lint]
 workspace = false
@@ -81,23 +84,52 @@ args = [
 
 [tasks.lint-vstyle]
 workspace = false
+dependencies = [
+	"lint-vstyle-rust",
+	"lint-vstyle-swift",
+]
+
+[tasks.lint-vstyle-rust]
+workspace = false
 command = "cargo"
 args = [
 	"vstyle",
 	"curate",
+	"--language",
+	"rust",
 	"--workspace",
 	"--all-features"
 ]
 
 [tasks.lint-fix-vstyle]
 workspace = false
+dependencies = [
+	"lint-fix-vstyle-rust",
+	"lint-vstyle-swift",
+]
+
+[tasks.lint-fix-vstyle-rust]
+workspace = false
 command = "cargo"
 args = [
 	"vstyle",
 	"tune",
+	"--language",
+	"rust",
 	"--workspace",
 	"--all-features",
 	"--strict",
+]
+
+[tasks.lint-vstyle-swift]
+workspace = false
+command = "cargo"
+args = [
+	"vstyle",
+	"curate",
+	"--language",
+	"swift",
+	"--workspace",
 ]
 
 

--- a/README.md
+++ b/README.md
@@ -127,18 +127,20 @@ After installation, you can run `cargo vstyle ...`.
 
 ### Basic commands
 
+`curate` and `tune` require an explicit `--language`.
+
 ```sh
 # Check style.
-vstyle curate
+vstyle curate --language rust
 
 # Apply safe fixes, then re-check.
-vstyle tune
+vstyle tune --language rust
 
 # Same as tune, but fail if violations remain.
-vstyle tune --strict
+vstyle tune --language rust --strict
 
 # Enable verbose output.
-vstyle tune --verbose
+vstyle tune --language rust --verbose
 
 # Print implemented rule IDs.
 vstyle coverage
@@ -148,17 +150,17 @@ vstyle coverage
 
 ```sh
 # Workspace-wide.
-vstyle curate --workspace
+vstyle curate --language rust --workspace
 
 # Swift workspace-wide.
-vstyle curate --workspace --language swift
+vstyle curate --language swift --workspace
 
 # Selected packages.
-vstyle tune -p api -p db-service
+vstyle tune --language rust -p api -p db-service
 
 # Feature flags.
-vstyle tune -p api --features serde,tracing
-vstyle tune -p api --all-features --no-default-features
+vstyle tune --language rust -p api --features serde,tracing
+vstyle tune --language rust -p api --all-features --no-default-features
 ```
 
 ### Exit behavior
@@ -170,7 +172,7 @@ vstyle tune -p api --all-features --no-default-features
   - Exit `0`: even if unresolved violations remain.
   - Exit `1`: unresolved violations remain and `--strict` is used.
 
-By default, `curate` and `tune` check Rust files. Use `--language swift` to check Swift files.
+Use `--language rust` to check Rust files and `--language swift` to check Swift files.
 File discovery scans every selected `*.rs` or `*.swift` file that is not matched by Git ignore
 rules inside that package scope. Git tracking state is not part of file discovery. With
 `--workspace`, Rust files are selected from workspace package roots and Swift files are selected
@@ -179,8 +181,8 @@ from the Cargo workspace root.
 ### CI policy
 
 CI runs language-specific `vstyle curate` commands (read-only verification) to keep feedback fast
-and deterministic. Use `vstyle tune` locally when you want to apply safe automatic fixes (for
-example, via `cargo make lint-fix`).
+and deterministic. Use language-specific `vstyle tune` commands locally when you want to apply safe
+automatic fixes (for example, via `cargo make lint-fix`).
 
 ### Release benchmark
 
@@ -194,7 +196,8 @@ cargo make bench-release-vstyle
 ```
 
 By default the harness builds the shipping `final-release` profile from `Cargo.toml` and runs both
-`vstyle curate --workspace` and `vstyle tune --workspace --verbose` inside a disposable Git
+`vstyle curate --language rust --workspace` and
+`vstyle tune --language rust --workspace --verbose` inside a disposable Git
 worktree at the current commit. This keeps `tune` from rewriting the primary checkout while still
 preserving the Git ignore boundary used for file discovery.
 
@@ -214,8 +217,8 @@ VSTYLE_BENCH_PROFILE=release cargo make bench-release-vstyle
 ```
 
 `cargo make lint-vstyle` remains the repo-native style gate, but it is not the release benchmark
-source of truth because it routes through `cargo vstyle curate --workspace` and can resolve to an
-installed subcommand outside the locally built binary under test.
+source of truth because it routes through language-specific `cargo vstyle curate` tasks and can
+resolve to an installed subcommand outside the locally built binary under test.
 
 ### Semantic benchmark
 
@@ -228,7 +231,7 @@ cargo make bench-semantic-vstyle
 
 This harness builds the local release binary once, creates a disposable Git fixture crate
 based on the `tests/let_mut_reorder.rs` semantic-validation shape, generates a local `Cargo.lock`,
-and runs `vstyle tune --verbose` twice:
+and runs `vstyle tune --language rust --verbose` twice:
 
 - a cold run after clearing `target/vstyle-cache/semantic`
 - a warm rerun after restoring the original fixture sources while keeping the cache directory
@@ -373,6 +376,10 @@ cargo make lint-rust
 
 # vibe-style only.
 cargo make lint-vstyle
+
+# vibe-style by language.
+cargo make lint-vstyle-rust
+cargo make lint-vstyle-swift
 
 # Rust tests.
 cargo make test-rust

--- a/docs/runbook/benchmark_tracking.md
+++ b/docs/runbook/benchmark_tracking.md
@@ -38,11 +38,11 @@ Verification:
 - File discovery follows Git ignore rules only: every non-ignored style file for the selected
   language is scanned, and tracking state does not affect local discovery.
 - If the change expands self-host style coverage, run
-  `target/final-release/vstyle curate --workspace` first and fix any newly reported repository drift
-  before treating timing results as meaningful.
+  `target/final-release/vstyle curate --language rust --workspace` first and fix any newly
+  reported repository drift before treating timing results as meaningful.
 - For an uncommitted current-worktree snapshot, time the local binary directly:
-  - `target/final-release/vstyle curate --workspace`
-  - `target/final-release/vstyle tune --workspace --verbose`
+  - `target/final-release/vstyle curate --language rust --workspace`
+  - `target/final-release/vstyle tune --language rust --workspace --verbose`
 - Treat those direct timings as pre-commit local evidence only.
 
 ## Commit-anchored release harness

--- a/docs/spec/swift_style_rule_applicability.md
+++ b/docs/spec/swift_style_rule_applicability.md
@@ -27,8 +27,10 @@ Defines:
 
 ## Backend Policy
 
-Rust remains the `vstyle` product shell: command-line parsing, file selection,
-diagnostic formatting, rule coverage, and exit behavior stay in Rust.
+The shared `vstyle` product shell remains implemented in Rust: command-line
+parsing, file selection, diagnostic formatting, rule coverage, and exit behavior
+stay in one host. This is an implementation boundary, not a priority order between
+Rust, Swift, or future language lanes.
 
 Swift rules that require Swift AST fidelity should use a SwiftSyntax-backed backend.
 The first Swift batch may use source-text checks only for rules whose syntax shape is

--- a/scripts/bench-release-vstyle.sh
+++ b/scripts/bench-release-vstyle.sh
@@ -117,8 +117,8 @@ summary_file="${log_dir}/summary.txt"
 	printf 'WORKTREE=%s\n' "$bench_worktree"
 	printf 'LOG_DIR=%s\n' "$log_dir"
 	printf 'VSTYLE_VERSION=%s\n' "$("$binary_path" --version)"
-	run_bench curate "$binary_path" curate --workspace
-	run_bench tune "$binary_path" tune --workspace --verbose
+	run_bench curate "$binary_path" curate --language rust --workspace
+	run_bench tune "$binary_path" tune --language rust --workspace --verbose
 } | tee "$summary_file"
 
 printf 'Benchmark summary saved to %s\n' "$summary_file"

--- a/scripts/bench-semantic-vstyle.sh
+++ b/scripts/bench-semantic-vstyle.sh
@@ -182,9 +182,9 @@ summary_file="${log_dir}/summary.txt"
 	printf 'FIXTURE_ROOT=%s\n' "$fixture_root"
 	printf 'LOG_DIR=%s\n' "$log_dir"
 	printf 'VSTYLE_VERSION=%s\n' "$("$binary_path" --version)"
-	run_bench cold_tune "$binary_path" tune --verbose
+	run_bench cold_tune "$binary_path" tune --language rust --verbose
 	write_fixture_sources
-	run_bench warm_tune "$binary_path" tune --verbose
+	run_bench warm_tune "$binary_path" tune --language rust --verbose
 } | tee "$summary_file"
 
 printf 'Benchmark summary saved to %s\n' "$summary_file"

--- a/skills/vstyle/SKILL.md
+++ b/skills/vstyle/SKILL.md
@@ -9,10 +9,10 @@ Use `vstyle` as a language-aware style gate. Do not treat one language lane as m
 important than another. Choose the lane from the user's request, changed files,
 repository wrappers, and current `vstyle` help.
 
-Current CLI fact: when `--language` is omitted, `vstyle curate` and `vstyle tune`
-use the default language lane. Today that default is Rust. Select Swift explicitly
-with `--language swift`. For future language lanes, inspect the repository wrapper
-or `vstyle <command> --help` instead of hard-coding assumptions.
+Current CLI fact: `vstyle curate` and `vstyle tune` require an explicit
+`--language`. Use `--language rust` for Rust and `--language swift` for Swift. For
+future language lanes, inspect the repository wrapper or `vstyle <command> --help`
+instead of hard-coding assumptions.
 
 ## Quick Workflow
 
@@ -49,33 +49,33 @@ or `vstyle <command> --help` instead of hard-coding assumptions.
 
 ## Command Recipes
 
-Current direct-command default lane validation. Today this default is Rust:
+Rust lane validation:
 
 ```sh
-vstyle curate
-vstyle curate --workspace
+vstyle curate --language rust
+vstyle curate --language rust --workspace
 ```
 
 Swift lane validation:
 
 ```sh
-vstyle curate --workspace --language swift
+vstyle curate --language swift --workspace
 ```
 
 Rust Cargo package and feature scoped validation:
 
 ```sh
-vstyle curate -p api --features serde,tracing
-vstyle curate -p api --all-features --no-default-features
+vstyle curate --language rust -p api --features serde,tracing
+vstyle curate --language rust -p api --all-features --no-default-features
 ```
 
 Safe fixes where the selected lane supports them:
 
 ```sh
-vstyle tune
-vstyle tune --strict
-vstyle tune -p api --all-features --strict
-vstyle tune --workspace --all-features --strict
+vstyle tune --language rust
+vstyle tune --language rust --strict
+vstyle tune --language rust -p api --all-features --strict
+vstyle tune --language rust --workspace --all-features --strict
 ```
 
 Rule discovery:
@@ -97,7 +97,7 @@ before assuming the right `--language` value or scope flags.
 - `coverage` prints implemented rule IDs for supported language lanes, such as
   `RUST-STYLE-*` and `SWIFT-STYLE-*`.
 - `curate` and `tune` use Cargo-like scope flags. They do not accept positional file
-  paths such as `vstyle curate src/lib.rs`.
+  paths such as `vstyle curate --language rust src/lib.rs`.
 - File discovery scans selected style files that are not Git-ignored. Git tracking
   state is not the filter, so non-ignored untracked files can be checked.
 - Today, `--workspace` selects Rust files from Cargo workspace package roots, and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,7 +110,7 @@ enum Command {
 #[derive(Clone, Debug, Args)]
 struct CargoCliOptions {
 	/// Source language to check.
-	#[arg(long = "language", value_enum, default_value_t = LanguageCliOption::Rust)]
+	#[arg(long = "language", value_enum, required = true)]
 	language: LanguageCliOption,
 	/// Check all packages in the workspace.
 	#[arg(long)]
@@ -202,30 +202,44 @@ mod tests {
 
 	#[test]
 	fn parses_curate_subcommand() {
-		let cli = Cli::parse_from(["app", "curate"]);
+		let cli = Cli::parse_from(["app", "curate", "--language", "rust"]);
 
 		assert!(matches!(cli.command, Command::Curate { strict: false, .. }));
 	}
 
 	#[test]
 	fn parses_curate_strict_subcommand() {
-		let cli = Cli::parse_from(["app", "curate", "--strict"]);
+		let cli = Cli::parse_from(["app", "curate", "--language", "rust", "--strict"]);
 
 		assert!(matches!(cli.command, Command::Curate { strict: true, .. }));
 	}
 
 	#[test]
 	fn parses_tune_subcommand() {
-		let cli = Cli::parse_from(["app", "tune"]);
+		let cli = Cli::parse_from(["app", "tune", "--language", "rust"]);
 
 		assert!(matches!(cli.command, Command::Tune { strict: false, .. }));
 	}
 
 	#[test]
 	fn parses_tune_strict_subcommand() {
-		let cli = Cli::parse_from(["app", "tune", "--strict"]);
+		let cli = Cli::parse_from(["app", "tune", "--language", "rust", "--strict"]);
 
 		assert!(matches!(cli.command, Command::Tune { strict: true, .. }));
+	}
+
+	#[test]
+	fn rejects_curate_without_language() {
+		let parsed = Cli::try_parse_from(["app", "curate"]);
+
+		assert!(parsed.is_err());
+	}
+
+	#[test]
+	fn rejects_tune_without_language() {
+		let parsed = Cli::try_parse_from(["app", "tune"]);
+
+		assert!(parsed.is_err());
 	}
 
 	#[test]
@@ -233,6 +247,8 @@ mod tests {
 		let cli = Cli::parse_from([
 			"app",
 			"tune",
+			"--language",
+			"rust",
 			"--workspace",
 			"-p",
 			"api",
@@ -255,7 +271,7 @@ mod tests {
 
 	#[test]
 	fn parses_curate_with_swift_language() {
-		let cli = Cli::parse_from(["app", "curate", "--workspace", "--language", "swift"]);
+		let cli = Cli::parse_from(["app", "curate", "--language", "swift", "--workspace"]);
 		let Command::Curate { cargo, .. } = cli.command else {
 			panic!("Expected curate command.");
 		};
@@ -267,14 +283,14 @@ mod tests {
 
 	#[test]
 	fn rejects_curate_positional_paths() {
-		let parsed = Cli::try_parse_from(["app", "curate", "src/main.rs"]);
+		let parsed = Cli::try_parse_from(["app", "curate", "--language", "rust", "src/main.rs"]);
 
 		assert!(parsed.is_err());
 	}
 
 	#[test]
 	fn rejects_tune_positional_paths() {
-		let parsed = Cli::try_parse_from(["app", "tune", "src/main.rs"]);
+		let parsed = Cli::try_parse_from(["app", "tune", "--language", "rust", "src/main.rs"]);
 
 		assert!(parsed.is_err());
 	}

--- a/src/style.rs
+++ b/src/style.rs
@@ -7986,7 +7986,10 @@ fn sample() {
 
 	#[test]
 	fn resolve_fix_round_scopes_workspace_splits_to_package_scopes() {
-		let cargo_options = shared::CargoOptions { workspace: true, ..Default::default() };
+		let cargo_options = shared::CargoOptions {
+			workspace: true,
+			..shared::CargoOptions::new(shared::StyleLanguage::Rust)
+		};
 		let workspace_files =
 			shared::resolve_files(&cargo_options).expect("resolve workspace files");
 		let scopes = super::resolve_fix_round_scopes(&cargo_options).expect("resolve fix scopes");
@@ -8007,11 +8010,17 @@ fn sample() {
 		let scopes = vec![
 			(
 				vec![PathBuf::from("a/src/lib.rs"), PathBuf::from("a/src/mod.rs")],
-				shared::CargoOptions { packages: vec!["a".to_owned()], ..Default::default() },
+				shared::CargoOptions {
+					packages: vec!["a".to_owned()],
+					..shared::CargoOptions::new(shared::StyleLanguage::Rust)
+				},
 			),
 			(
 				vec![PathBuf::from("b/src/lib.rs")],
-				shared::CargoOptions { packages: vec!["b".to_owned()], ..Default::default() },
+				shared::CargoOptions {
+					packages: vec!["b".to_owned()],
+					..shared::CargoOptions::new(shared::StyleLanguage::Rust)
+				},
 			),
 		];
 
@@ -8023,11 +8032,17 @@ fn sample() {
 		let scopes = vec![
 			(
 				vec![PathBuf::from("shared/src/lib.rs")],
-				shared::CargoOptions { packages: vec!["a".to_owned()], ..Default::default() },
+				shared::CargoOptions {
+					packages: vec!["a".to_owned()],
+					..shared::CargoOptions::new(shared::StyleLanguage::Rust)
+				},
 			),
 			(
 				vec![PathBuf::from("shared/src/lib.rs"), PathBuf::from("b/src/lib.rs")],
-				shared::CargoOptions { packages: vec!["b".to_owned()], ..Default::default() },
+				shared::CargoOptions {
+					packages: vec!["b".to_owned()],
+					..shared::CargoOptions::new(shared::StyleLanguage::Rust)
+				},
 			),
 		];
 
@@ -8117,7 +8132,7 @@ fn sample() {
 
 		let summary = super::run_fix_round(
 			slice::from_ref(&path),
-			&shared::CargoOptions::default(),
+			&shared::CargoOptions::new(shared::StyleLanguage::Rust),
 			false,
 			false,
 		)

--- a/src/style/shared.rs
+++ b/src/style/shared.rs
@@ -142,7 +142,7 @@ pub(crate) struct RunSummary {
 	pub(crate) output_lines: Vec<String>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct CargoOptions {
 	pub(crate) language: StyleLanguage,
 	pub(crate) workspace: bool,
@@ -151,10 +151,22 @@ pub(crate) struct CargoOptions {
 	pub(crate) all_features: bool,
 	pub(crate) no_default_features: bool,
 }
+impl CargoOptions {
+	#[cfg(test)]
+	pub(crate) fn new(language: StyleLanguage) -> Self {
+		Self {
+			language,
+			workspace: false,
+			packages: Vec::new(),
+			features: Vec::new(),
+			all_features: false,
+			no_default_features: false,
+		}
+	}
+}
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum StyleLanguage {
-	#[default]
 	Rust,
 	Swift,
 }

--- a/tests/let_mut_reorder.rs
+++ b/tests/let_mut_reorder.rs
@@ -74,7 +74,7 @@ pub fn closure_carries_binding() {
 
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
-		.arg("tune")
+		.args(["tune", "--language", "rust"])
 		.output()
 		.expect("run vstyle");
 
@@ -143,7 +143,7 @@ pub fn closure_carries_binding() {
 
 	let cold = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
-		.args(["tune", "--verbose"])
+		.args(["tune", "--language", "rust", "--verbose"])
 		.output()
 		.expect("run cold vstyle");
 
@@ -165,7 +165,7 @@ pub fn closure_carries_binding() {
 
 	let warm = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
-		.args(["tune", "--verbose"])
+		.args(["tune", "--language", "rust", "--verbose"])
 		.output()
 		.expect("run warm vstyle");
 

--- a/tests/mod007_super_import.rs
+++ b/tests/mod007_super_import.rs
@@ -88,7 +88,7 @@ mod tests {
 
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
-		.arg("tune")
+		.args(["tune", "--language", "rust"])
 		.output()
 		.expect("run vstyle");
 

--- a/tests/pub_use_self_group.rs
+++ b/tests/pub_use_self_group.rs
@@ -67,7 +67,7 @@ pub struct AddNoteResponse;
 
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
-		.arg("tune")
+		.args(["tune", "--language", "rust"])
 		.output()
 		.expect("run vstyle");
 

--- a/tests/swift_curate.rs
+++ b/tests/swift_curate.rs
@@ -2,7 +2,7 @@
 
 use std::{
 	env, fs,
-	path::PathBuf,
+	path::{Path, PathBuf},
 	process::{self, Command},
 	time::{SystemTime, UNIX_EPOCH},
 };
@@ -44,9 +44,7 @@ edition = "2021"
 	root
 }
 
-#[test]
-fn curate_reports_swift_workspace_violations_from_non_ignored_files() {
-	let temp_dir = create_temp_workspace_root();
+fn write_swift_fixture(temp_dir: &Path) {
 	let long_body = (0..121).map(|idx| format!("\tlet value{idx} = {idx}\n")).collect::<String>();
 	let swift_source = format!(
 		"import Foundation\n\
@@ -78,9 +76,11 @@ func testForceAllowed() {
 		.expect("write tracked ignored Swift source");
 	fs::write(temp_dir.join("Tests/AppTests.swift"), swift_test_source)
 		.expect("write Swift test source");
+}
 
+fn initialize_git_fixture(temp_dir: &Path) {
 	let status =
-		Command::new("git").current_dir(&temp_dir).args(["init"]).output().expect("git init");
+		Command::new("git").current_dir(temp_dir).args(["init"]).output().expect("git init");
 
 	assert!(
 		status.status.success(),
@@ -89,7 +89,7 @@ func testForceAllowed() {
 	);
 
 	let status = Command::new("git")
-		.current_dir(&temp_dir)
+		.current_dir(temp_dir)
 		.args([
 			"add",
 			"-f",
@@ -108,16 +108,32 @@ func testForceAllowed() {
 		"expected git add to succeed, stderr: {}",
 		String::from_utf8_lossy(&status.stderr)
 	);
+}
 
+fn assert_curate_requires_explicit_language(temp_dir: &Path) {
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
-		.current_dir(&temp_dir)
+		.current_dir(temp_dir)
 		.args(["curate", "--workspace"])
+		.output()
+		.expect("run vstyle");
+
+	assert!(!output.status.success(), "curate without an explicit language should fail");
+
+	let stderr = String::from_utf8_lossy(&output.stderr);
+
+	assert!(stderr.contains("--language"), "expected missing language diagnostic:\n{stderr}");
+}
+
+fn assert_rust_curate_ignores_swift(temp_dir: &Path) {
+	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
+		.current_dir(temp_dir)
+		.args(["curate", "--language", "rust", "--workspace"])
 		.output()
 		.expect("run vstyle");
 
 	assert!(
 		output.status.success(),
-		"default Rust-only curate should ignore Swift violations, stderr: {}",
+		"explicit Rust curate should ignore Swift violations, stderr: {}",
 		String::from_utf8_lossy(&output.stderr)
 	);
 
@@ -125,12 +141,14 @@ func testForceAllowed() {
 
 	assert!(
 		!stdout.contains("Sources/App/mod.swift"),
-		"default Rust-only curate should not scan Swift files:\n{stdout}"
+		"explicit Rust curate should not scan Swift files:\n{stdout}"
 	);
+}
 
+fn assert_swift_curate_reports_expected_violations(temp_dir: &Path) {
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
-		.current_dir(&temp_dir)
-		.args(["curate", "--workspace", "--language", "swift"])
+		.current_dir(temp_dir)
+		.args(["curate", "--language", "swift", "--workspace"])
 		.output()
 		.expect("run vstyle");
 
@@ -162,4 +180,15 @@ func testForceAllowed() {
 		!stdout.contains("IgnoredTracked.swift"),
 		"git-ignored Swift files should not be scanned even when tracked"
 	);
+}
+
+#[test]
+fn curate_reports_swift_workspace_violations_from_non_ignored_files() {
+	let temp_dir = create_temp_workspace_root();
+
+	write_swift_fixture(&temp_dir);
+	initialize_git_fixture(&temp_dir);
+	assert_curate_requires_explicit_language(&temp_dir);
+	assert_rust_curate_ignores_swift(&temp_dir);
+	assert_swift_curate_reports_expected_violations(&temp_dir);
 }

--- a/tests/type_alias_rename.rs
+++ b/tests/type_alias_rename.rs
@@ -68,7 +68,7 @@ pub fn build_error() -> MyError {
 
 	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
 		.current_dir(&temp_dir)
-		.arg("tune")
+		.args(["tune", "--language", "rust"])
 		.output()
 		.expect("run vstyle");
 


### PR DESCRIPTION
## Summary
- Require `curate` and `tune` callers to pass an explicit `--language` instead of falling back to Rust.
- Split repo `cargo make lint-vstyle` into explicit Rust and Swift lanes and update benchmark scripts to pass `--language rust`.
- Sync README, runbook, spec wording, repo skill, and installed local Codex skill guidance for current and future language lanes.

## Verification
- `cargo make checks`
- `python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py`
- `git diff --check`
- `cargo run --quiet --bin vstyle -- curate --workspace` fails and reports `--language <LANGUAGE>`
- `cargo run --quiet --bin vstyle -- curate --language rust --workspace`
- `cargo run --quiet --bin vstyle -- curate --language swift --workspace`

## Note
Language Checks currently installs the latest released `vstyle`; that CI lane may fail until the next release contains this CLI change.
