### PR TITLE
Fix Reverse import style

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -40,18 +40,8 @@ jobs:
         with:
           tool: cargo-make
 
-      - name: Install vibe-style (latest release)
-        run: |
-          set -euo pipefail
-          VERSION="$(curl -fsSL https://api.github.com/repos/hack-ink/vibe-style/releases/latest | grep -oE '"tag_name": "v[^"]+"' | cut -d'"' -f4)"
-          TARGET="x86_64-unknown-linux-gnu"
-          ASSET="vibe-style-${TARGET}-${VERSION}.tgz"
-
-          curl -fsSLO "https://github.com/hack-ink/vibe-style/releases/download/${VERSION}/${ASSET}"
-          tar -xzf "${ASSET}"
-
-          sudo install -m 0755 "vibe-style-${TARGET}-${VERSION}/vstyle" /usr/local/bin/vstyle
-          sudo install -m 0755 "vibe-style-${TARGET}-${VERSION}/cargo-vstyle" /usr/local/bin/cargo-vstyle
+      - name: Install vibe-style from checkout
+        run: cargo install --path . --bin vstyle --bin cargo-vstyle --locked
 
       - name: Install nextest
         uses: taiki-e/install-action@v2

--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ from the Cargo workspace root.
 
 ### CI policy
 
-CI runs language-specific `vstyle curate` commands (read-only verification) to keep feedback fast
-and deterministic. Use language-specific `vstyle tune` commands locally when you want to apply safe
-automatic fixes (for example, via `cargo make lint-fix`).
+CI installs `vstyle` and `cargo-vstyle` from the current checkout, then runs language-specific
+`vstyle curate` commands (read-only verification) to keep feedback fast and deterministic. Use
+language-specific `vstyle tune` commands locally when you want to apply safe automatic fixes (for
+example, via `cargo make lint-fix`).
 
 ### Release benchmark
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -25,7 +25,7 @@ use color_eyre::Result;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use semantic::SemanticCacheStats;
-use shared::{Edit, FileContext, Violation};
+use shared::{Edit, FileContext, STYLE_RULE_IDS, Violation};
 
 type FixRoundScope = (Vec<PathBuf>, CargoOptions);
 
@@ -225,7 +225,7 @@ pub(crate) fn semantic_cache_stats() -> SemanticCacheStats {
 }
 
 pub(crate) fn print_coverage() {
-	for rule in shared::STYLE_RULE_IDS {
+	for rule in STYLE_RULE_IDS {
 		println!("{rule}\timplemented");
 	}
 }
@@ -4358,6 +4358,48 @@ fn sort(values: &mut [usize]) {
 		assert!(rewritten.contains("use std::cmp::Reverse;"), "{rewritten}");
 		assert!(rewritten.contains("Reverse(*value)"), "{rewritten}");
 		assert!(!rewritten.contains("std::cmp::Reverse(*value)"), "{rewritten}");
+	}
+
+	#[test]
+	fn import008_shortens_type_like_value_constants_without_primitive_constants() {
+		let original = r#"
+mod shared {
+	pub const STYLE_RULE_IDS: [&str; 0] = [];
+}
+
+fn max_value() -> usize {
+	usize::MAX
+}
+
+fn print_coverage() {
+	for rule in shared::STYLE_RULE_IDS {
+		println!("{rule}");
+	}
+}
+"#;
+		let mut rewritten = original.to_owned();
+
+		for _ in 0..4 {
+			let ctx = shared::read_file_context_from_text(
+				Path::new("import008_type_like_value_constants.rs"),
+				rewritten.clone(),
+			)
+			.expect("context")
+			.expect("has ctx");
+			let (_violations, edits) = crate::style::collect_violations(&ctx, true);
+
+			if edits.is_empty() {
+				break;
+			}
+
+			let _applied = fixes::apply_edits(&mut rewritten, edits).expect("apply edits");
+		}
+
+		assert!(rewritten.contains("use shared::STYLE_RULE_IDS;"), "{rewritten}");
+		assert!(rewritten.contains("for rule in STYLE_RULE_IDS"), "{rewritten}");
+		assert!(rewritten.contains("usize::MAX"), "{rewritten}");
+		assert!(!rewritten.contains("use usize::MAX"), "{rewritten}");
+		assert!(!rewritten.contains("for rule in shared::STYLE_RULE_IDS"), "{rewritten}");
 	}
 
 	#[test]

--- a/src/style.rs
+++ b/src/style.rs
@@ -4331,6 +4331,36 @@ fn demo(v: Vec<shared::Violation>) -> Option<shared::Violation> {
 	}
 
 	#[test]
+	fn import008_shortens_type_like_value_constructor_paths() {
+		let original = r#"
+fn sort(values: &mut [usize]) {
+	values.sort_by_key(|value| std::cmp::Reverse(*value));
+}
+"#;
+		let mut rewritten = original.to_owned();
+
+		for _ in 0..4 {
+			let ctx = shared::read_file_context_from_text(
+				Path::new("import008_type_like_value_constructor.rs"),
+				rewritten.clone(),
+			)
+			.expect("context")
+			.expect("has ctx");
+			let (_violations, edits) = crate::style::collect_violations(&ctx, true);
+
+			if edits.is_empty() {
+				break;
+			}
+
+			let _applied = fixes::apply_edits(&mut rewritten, edits).expect("apply edits");
+		}
+
+		assert!(rewritten.contains("use std::cmp::Reverse;"), "{rewritten}");
+		assert!(rewritten.contains("Reverse(*value)"), "{rewritten}");
+		assert!(!rewritten.contains("std::cmp::Reverse(*value)"), "{rewritten}");
+	}
+
+	#[test]
 	fn import008_skips_non_importable_self_root_paths() {
 		let text = r#"
 trait Job {

--- a/src/style/imports.rs
+++ b/src/style/imports.rs
@@ -30,6 +30,7 @@ type Import009Plan<'a> = (
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Import008CandidateKind {
 	TypePath,
+	ValueConstructor,
 	ValueReceiver,
 	MacroModule,
 	Derive,
@@ -3341,7 +3342,10 @@ fn build_import008_blocked_symbols(
 			.or_default()
 			.insert(candidate.import_path.clone());
 
-		if candidate.kind != Import008CandidateKind::ValueReceiver {
+		if !matches!(
+			candidate.kind,
+			Import008CandidateKind::ValueReceiver | Import008CandidateKind::ValueConstructor
+		) {
 			non_value_receiver_candidate_symbols.insert(candidate.symbol.clone());
 		}
 	}
@@ -3991,6 +3995,7 @@ fn collect_import008_candidates(ctx: &FileContext) -> Vec<Import008Candidate> {
 	let mut seen_ranges = HashSet::new();
 
 	collect_import008_from_paths(ctx, &mut candidates, &mut seen_ranges);
+	collect_import008_from_type_like_value_paths(ctx, &mut candidates, &mut seen_ranges);
 	collect_import008_from_value_receivers(ctx, &mut candidates, &mut seen_ranges);
 	collect_import008_from_macro_calls(ctx, &mut candidates, &mut seen_ranges);
 	collect_import008_from_derive_attrs(ctx, &derive_path_re, &mut candidates, &mut seen_ranges);
@@ -4065,6 +4070,71 @@ fn collect_import008_from_paths(
 			symbol,
 			import_path,
 			replacement,
+		});
+	}
+}
+
+fn collect_import008_from_type_like_value_paths(
+	ctx: &FileContext,
+	candidates: &mut Vec<Import008Candidate>,
+	seen_ranges: &mut HashSet<(usize, usize)>,
+) {
+	for path in ctx.source_file.syntax().descendants().filter_map(ast::Path::cast) {
+		let Some(candidate) = classify_value_path_candidate(
+			ctx,
+			path,
+			PathQualificationRequirement::Qualified,
+			false,
+			true,
+		) else {
+			continue;
+		};
+		let mut segments = Vec::new();
+
+		if !collect_path_segment_texts(&candidate.path, &mut segments) {
+			continue;
+		}
+		if segments.len() < 2 {
+			continue;
+		}
+
+		let symbol = normalize_ident(segments[segments.len() - 1].as_str()).to_owned();
+
+		if !is_import009_type_like_symbol(&symbol) {
+			continue;
+		}
+		if segments
+			.get(segments.len().saturating_sub(2))
+			.is_some_and(|segment| is_import009_type_like_symbol(normalize_ident(segment)))
+		{
+			continue;
+		}
+
+		let root = segments[0].as_str();
+
+		if is_non_importable_root(root) {
+			continue;
+		}
+
+		let import_path = segments.join("::");
+		let range = candidate.path.syntax().text_range();
+		let start = usize::from(range.start());
+		let end = usize::from(range.end());
+
+		if start >= end || !seen_ranges.insert((start, end)) {
+			continue;
+		}
+
+		let line = shared::line_from_offset(&ctx.line_starts, start);
+
+		candidates.push(Import008Candidate {
+			line,
+			start,
+			end,
+			kind: Import008CandidateKind::ValueConstructor,
+			symbol,
+			import_path,
+			replacement: candidate.name_ref.text().to_string(),
 		});
 	}
 }

--- a/src/style/imports.rs
+++ b/src/style/imports.rs
@@ -30,7 +30,7 @@ type Import009Plan<'a> = (
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Import008CandidateKind {
 	TypePath,
-	ValueConstructor,
+	ValuePath,
 	ValueReceiver,
 	MacroModule,
 	Derive,
@@ -3344,7 +3344,7 @@ fn build_import008_blocked_symbols(
 
 		if !matches!(
 			candidate.kind,
-			Import008CandidateKind::ValueReceiver | Import008CandidateKind::ValueConstructor
+			Import008CandidateKind::ValueReceiver | Import008CandidateKind::ValuePath
 		) {
 			non_value_receiver_candidate_symbols.insert(candidate.symbol.clone());
 		}
@@ -4115,6 +4115,9 @@ fn collect_import008_from_type_like_value_paths(
 		if is_non_importable_root(root) {
 			continue;
 		}
+		if is_primitive_associated_value_path(&segments) {
+			continue;
+		}
 
 		let import_path = segments.join("::");
 		let range = candidate.path.syntax().text_range();
@@ -4131,12 +4134,37 @@ fn collect_import008_from_type_like_value_paths(
 			line,
 			start,
 			end,
-			kind: Import008CandidateKind::ValueConstructor,
+			kind: Import008CandidateKind::ValuePath,
 			symbol,
 			import_path,
 			replacement: candidate.name_ref.text().to_string(),
 		});
 	}
+}
+
+fn is_primitive_associated_value_path(segments: &[String]) -> bool {
+	match segments {
+		[receiver, _] => is_rust_primitive_type_ident(receiver),
+		[root, primitive_module, receiver, _]
+			if matches!(root.as_str(), "core" | "std") && primitive_module == "primitive" =>
+			is_rust_primitive_type_ident(receiver),
+		_ => false,
+	}
+}
+
+fn is_rust_primitive_type_ident(segment: &str) -> bool {
+	matches!(
+		normalize_ident(segment),
+		"bool"
+			| "char" | "f32"
+			| "f64" | "i8"
+			| "i16" | "i32"
+			| "i64" | "i128"
+			| "isize" | "str"
+			| "u8" | "u16"
+			| "u32" | "u64"
+			| "u128" | "usize"
+	)
 }
 
 fn collect_import008_from_value_receivers(

--- a/src/style/semantic.rs
+++ b/src/style/semantic.rs
@@ -1,4 +1,5 @@
 use std::{
+	cmp::Reverse,
 	collections::{BTreeMap, BTreeSet},
 	env, fs,
 	io::ErrorKind,
@@ -579,7 +580,7 @@ fn apply_missing_import_suggestions(
 	let mut applied = 0_usize;
 	let mut ordered = suggestions.to_vec();
 
-	ordered.sort_by_key(|suggestion| std::cmp::Reverse(suggestion.line));
+	ordered.sort_by_key(|suggestion| Reverse(suggestion.line));
 
 	for suggestion in ordered {
 		let line_start = line_start_offset(&text, suggestion.line).unwrap_or(0);


### PR DESCRIPTION
## Summary
- Extend `RUST-STYLE-IMPORT-008` to shorten type-like value paths, including tuple-style constructors such as `std::cmp::Reverse(...)` and importable constants such as `shared::STYLE_RULE_IDS`.
- Keep non-importable primitive associated constants such as `usize::MAX` qualified, and update the repository's own `Reverse` / `STYLE_RULE_IDS` usages to match the rule.
- Install `vstyle`/`cargo-vstyle` from the current checkout in Language Checks so CI validates the PR's checker behavior.

## Verification
- `cargo make checks`
- `cargo make lint`
- `cargo test import008_shortens_type_like_value --all-features`
- `cargo install --path . --bin vstyle --bin cargo-vstyle --locked --force`
- `CARGO_TARGET_DIR=target/local-install-refresh cargo install --path . --bin vstyle --bin cargo-vstyle --locked --force`
- `python3 /Users/x/.codex/plugins/cache/hack-ink/playbook/0.3.0/scripts/semantic_drift_audit.py --rev origin/main...HEAD`
- `git diff --check`
