### PR TITLE
Release v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-style"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name        = "vibe-style"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/vibe-style"
 resolver    = "3"
-version     = "0.2.0"
+version     = "0.2.1"
 
 [[bin]]
 name = "vstyle"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Use the composite action to install a prebuilt release and run a read-only style
 
 The action runs `vstyle curate --language <language>`, adds `--workspace` when
 `workspace: true`, and appends `args`. Use `language: swift` for Swift checks, and use
-`version: v0.2.0` when CI should pin a specific `vibe-style` release. Use
+`version: v0.2.1` when CI should pin a specific `vibe-style` release. Use
 `version: checkout` only when the workflow should build `vibe-style` from the action
 checkout, such as this repository's own local `uses: ./` workflow.
 


### PR DESCRIPTION
## Summary
- Bump workspace/package version to v0.2.1
- Update README GitHub Action pin example to v0.2.1
- Refresh Cargo.lock for the package version

## Verification
- cargo make fmt-check
- cargo make lint
- cargo make test-rust
- cargo publish --dry-run --locked
- semantic drift audit: README version claim matches Cargo.toml v0.2.1