### PR TITLE
Sync language check structure

### DIFF
--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -8,9 +8,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+      - 'docs/**'
   merge_group:
 
 concurrency:
@@ -18,8 +26,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  cargo-clippy:
-    name: Task cargo clippy
+  rust-check:
+    name: Rust check
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
@@ -40,7 +48,15 @@ jobs:
         with:
           tool: cargo-make
 
-      - name: Run vibe-style
+      - name: Install nextest
+        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
+        with:
+          tool: nextest
+
+      - name: Run Rust format check
+        run: cargo make fmt-rust-check
+
+      - name: Run Rust style check
         uses: ./
         with:
           language: rust
@@ -48,11 +64,14 @@ jobs:
           args: --all-features
           version: checkout
 
-      - name: Run Rust lint
-        run: cargo make lint-rust
+      - name: Run Rust clippy
+        run: cargo make check-rust
 
-  cargo-fmt:
-    name: Task cargo fmt
+      - name: Run tests
+        run: cargo make test-rust
+
+  toml-check:
+    name: TOML check
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
@@ -63,10 +82,6 @@ jobs:
         with:
           cache: true
           rustflags: ''
-          components: rustfmt
-
-      - name: Install nightly rustfmt
-        run: rustup toolchain install nightly --component rustfmt
 
       - name: Install cargo-make
         uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
@@ -78,31 +93,5 @@ jobs:
         with:
           tool: taplo
 
-      - name: Run format checks
-        run: cargo make fmt-check
-
-  cargo-nextest:
-    name: Task cargo nextest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch latest code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          cache: true
-          rustflags: ''
-
-      - name: Install cargo-make
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
-        with:
-          tool: cargo-make
-
-      - name: Install nextest
-        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
-        with:
-          tool: nextest
-
-      - name: Run tests
-        run: cargo make test-rust
+      - name: Run TOML format check
+        run: cargo make fmt-toml-check

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,33 +1,23 @@
 # Rust workspace tasks.
 
-# Lint
-# | task                 | type      | cwd |
-# | -------------------- | --------- | --- |
-# | lint                 | composite |     |
-# | lint-fix             | composite |     |
-# | lint-rust            | command   |     |
-# | lint-fix-rust        | extend    |     |
-# | lint-vstyle          | composite |     |
-# | lint-vstyle-rust     | command   |     |
-# | lint-vstyle-swift    | command   |     |
-# | lint-fix-vstyle      | composite |     |
-# | lint-fix-vstyle-rust | command   |     |
+# Check
+# | task         | type      | cwd |
+# | ------------ | --------- | --- |
+# | check        | composite |     |
+# | check-rust   | command   |     |
+# | check-vstyle | command   |     |
 
-[tasks.lint]
+[tasks.check]
+clear = true
 workspace = false
 dependencies = [
-	"lint-rust",
-	"lint-vstyle",
+	"fmt-check",
+	"check-rust",
+	"check-vstyle",
+	"test",
 ]
 
-[tasks.lint-fix]
-workspace = false
-dependencies = [
-	"lint-fix-rust",
-	"lint-fix-vstyle",
-]
-
-[tasks.lint-rust]
+[tasks.check-rust]
 workspace = false
 command = "cargo"
 args = [
@@ -54,42 +44,7 @@ args = [
 	"warnings",
 ]
 
-[tasks.lint-fix-rust]
-extend = "lint-rust"
-args = [
-	"clippy",
-	"--fix",
-	"--allow-dirty",
-	"--all-features",
-	"--all-targets",
-	"--workspace",
-	"--",
-	"-D",
-	"clippy::all",
-	"-D",
-	"clippy::too_many_lines",
-	"-D",
-	"clippy::unwrap_used",
-	"-D",
-	"clippy::use_self",
-	"-D",
-	"clippy::wildcard_imports",
-	"-D",
-	"missing-docs",
-	"-D",
-	"unused-crate-dependencies",
-	"-D",
-	"warnings",
-]
-
-[tasks.lint-vstyle]
-workspace = false
-dependencies = [
-	"lint-vstyle-rust",
-	"lint-vstyle-swift",
-]
-
-[tasks.lint-vstyle-rust]
+[tasks.check-vstyle]
 workspace = false
 command = "cargo"
 args = [
@@ -100,62 +55,6 @@ args = [
 	"--workspace",
 	"--all-features"
 ]
-
-[tasks.lint-fix-vstyle]
-workspace = false
-dependencies = [
-	"lint-fix-vstyle-rust",
-	"lint-vstyle-swift",
-]
-
-[tasks.lint-fix-vstyle-rust]
-workspace = false
-command = "cargo"
-args = [
-	"vstyle",
-	"tune",
-	"--language",
-	"rust",
-	"--workspace",
-	"--all-features",
-	"--strict",
-]
-
-[tasks.lint-vstyle-swift]
-workspace = false
-command = "cargo"
-args = [
-	"vstyle",
-	"curate",
-	"--language",
-	"swift",
-	"--workspace",
-]
-
-
-# Test
-# | task      | type      | cwd |
-# | --------- | --------- | --- |
-# | test      | composite |     |
-# | test-rust | command   |     |
-
-[tasks.test]
-workspace = false
-dependencies = [
-	"test-rust",
-]
-
-[tasks.test-rust]
-workspace = false
-command = "cargo"
-args = [
-	"nextest",
-	"run",
-	"--workspace",
-	"--all-targets",
-	"--all-features",
-]
-
 
 # Format
 # | task           | type      | cwd |
@@ -203,13 +102,91 @@ args = [
 	"--check",
 ]
 
+# Lint
+# | task        | type      | cwd |
+# | ----------- | --------- | --- |
+# | lint        | composite |     |
+# | lint-rust   | command   |     |
+# | lint-vstyle | command   |     |
+
+[tasks.lint]
+workspace = false
+dependencies = [
+	"lint-rust",
+	"lint-vstyle",
+]
+
+[tasks.lint-rust]
+workspace = false
+command = "cargo"
+args = [
+	"clippy",
+	"--fix",
+	"--allow-dirty",
+	"--all-features",
+	"--all-targets",
+	"--workspace",
+	"--",
+	"-D",
+	"clippy::all",
+	"-D",
+	"clippy::too_many_lines",
+	"-D",
+	"clippy::unwrap_used",
+	"-D",
+	"clippy::use_self",
+	"-D",
+	"clippy::wildcard_imports",
+	"-D",
+	"missing-docs",
+	"-D",
+	"unused-crate-dependencies",
+	"-D",
+	"warnings",
+]
+
+[tasks.lint-vstyle]
+workspace = false
+command = "cargo"
+args = [
+	"vstyle",
+	"tune",
+	"--language",
+	"rust",
+	"--workspace",
+	"--all-features",
+	"--strict",
+]
+
+# Test
+# | task      | type      | cwd |
+# | --------- | --------- | --- |
+# | test      | composite |     |
+# | test-rust | command   |     |
+
+[tasks.test]
+clear = true
+workspace = false
+dependencies = [
+	"test-rust",
+]
+
+[tasks.test-rust]
+workspace = false
+command = "cargo"
+args = [
+	"nextest",
+	"run",
+	"--workspace",
+	"--all-targets",
+	"--all-features",
+]
 
 # Meta
-# | task                  | type      | cwd |
-# | --------------------- | --------- | --- |
-# | bench-release-vstyle  | command   |     |
-# | bench-semantic-vstyle | command   |     |
-# | checks                | composite |     |
+# | task                  | type    | cwd |
+# | --------------------- | ------- | --- |
+# | bench-release-vstyle  | command |     |
+# | bench-semantic-vstyle | command |     |
 
 [tasks.bench-release-vstyle]
 workspace = false
@@ -223,12 +200,4 @@ workspace = false
 command = "bash"
 args = [
 	"scripts/bench-semantic-vstyle.sh",
-]
-
-[tasks.checks]
-workspace = false
-dependencies = [
-	"fmt-check",
-	"lint",
-	"test",
 ]

--- a/README.md
+++ b/README.md
@@ -199,10 +199,9 @@ from the Cargo workspace root.
 
 ### CI policy
 
-CI installs `vstyle` and `cargo-vstyle` from the current checkout, then runs language-specific
-`vstyle curate` commands (read-only verification) to keep feedback fast and deterministic. Use
-language-specific `vstyle tune` commands locally when you want to apply safe automatic fixes (for
-example, via `cargo make lint-fix`).
+CI runs the checked-out action for Rust read-only style verification to keep feedback fast and
+deterministic. Use `vstyle tune` locally when you want to apply safe automatic fixes (for example,
+via `cargo make lint`).
 
 ### Release benchmark
 
@@ -388,24 +387,23 @@ This repository uses `cargo make` tasks from `Makefile.toml`.
 cargo make fmt
 cargo make fmt-check
 
-# Lint (clippy + vibe-style).
+# Full read-only verification.
+cargo make check
+
+# Rust-only clippy check.
+cargo make check-rust
+
+# vibe-style read-only check.
+cargo make check-vstyle
+
+# Apply lint fixes (clippy + vibe-style).
 cargo make lint
 
-# Rust-only clippy.
-cargo make lint-rust
-
-# vibe-style only.
+# Apply vibe-style fixes.
 cargo make lint-vstyle
-
-# vibe-style by language.
-cargo make lint-vstyle-rust
-cargo make lint-vstyle-swift
 
 # Rust tests.
 cargo make test-rust
-
-# Full checks.
-cargo make checks
 ```
 
 ## Documentation

--- a/skills/vstyle/SKILL.md
+++ b/skills/vstyle/SKILL.md
@@ -20,7 +20,7 @@ instead of hard-coding assumptions.
    - Prefer checked-in wrappers from `Makefile.toml`, `justfile`, `Makefile`,
      package scripts, CI workflows, or repository docs.
    - Wrapper names may be generic (`style`, `style-check`, `fmt`, `fmt-check`,
-     `lint`, `checks`) or language-specific (`lint-vstyle`, `lint-vstyle-swift`).
+     `check`, `lint`) or style-specific (`check-vstyle`, `lint-vstyle`).
    - Use direct `vstyle` commands only when no relevant repository wrapper exists.
 2. Determine language lanes.
    - Rust lane: changed `*.rs` files or a Rust-focused wrapper.


### PR DESCRIPTION
## Summary
- align Makefile language-check tasks with the Maestro check/fmt/lint/test tree
- collapse language CI into rust-check and toml-check jobs with the Maestro step order
- update README and vstyle skill docs for the renamed task entrypoints

## Verification
- actionlint .github/workflows/language.yml .github/workflows/benchmark.yml .github/workflows/release.yml
- cargo make check
- semantic drift audit: no stale task references
- git diff --check