### PR TITLE
Speed up vstyle tune telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-style"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name        = "vibe-style"
 readme      = "README.md"
 repository  = "https://github.com/hack-ink/vibe-style"
 resolver    = "3"
-version     = "0.2.1"
+version     = "0.2.2"
 
 [[bin]]
 name = "vstyle"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Use the composite action to install a prebuilt release and run a read-only style
 
 The action runs `vstyle curate --language <language>`, adds `--workspace` when
 `workspace: true`, and appends `args`. Use `language: swift` for Swift checks, and use
-`version: v0.2.1` when CI should pin a specific `vibe-style` release. Use
+`version: v0.2.2` when CI should pin a specific `vibe-style` release. Use
 `version: checkout` only when the workflow should build `vibe-style` from the action
 checkout, such as this repository's own local `uses: ./` workflow.
 
@@ -158,12 +158,17 @@ vstyle tune --language rust
 # Same as tune, but fail if violations remain.
 vstyle tune --language rust --strict
 
-# Enable verbose output.
+# Include verbose cache diagnostics in addition to tune progress.
 vstyle tune --language rust --verbose
 
 # Print implemented rule IDs.
 vstyle coverage
 ```
+
+`tune` prints progress telemetry to stderr for the initial scan, each fix round, scoped
+fix batches, semantic validation, and the final scan when fixes were applied. This
+output is emitted even when stderr is redirected so long-running workspace repairs
+remain observable in logs.
 
 ### Cargo-like target selection
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,4 @@
-use std::{
-	io::{self, IsTerminal},
-	process::ExitCode,
-};
+use std::process::ExitCode;
 
 use clap::{
 	Args, Parser, Subcommand, ValueEnum,
@@ -59,8 +56,7 @@ impl Cli {
 				}
 			},
 			Command::Tune { strict, cargo } => {
-				let summary =
-					style::run_fix(&cargo.as_options(), verbose, io::stderr().is_terminal())?;
+				let summary = style::run_fix(&cargo.as_options(), verbose, true)?;
 
 				print_summary(&summary, true);
 				print_semantic_cache_stats(verbose);

--- a/src/style.rs
+++ b/src/style.rs
@@ -19,6 +19,7 @@ use std::{
 	collections::{BTreeMap, BTreeSet},
 	fs, mem,
 	path::{Path, PathBuf},
+	time::{Duration, Instant},
 };
 
 use color_eyre::Result;
@@ -115,6 +116,16 @@ struct SemanticValidationFallbacks<'a> {
 	type_alias_rename_files: &'a BTreeMap<PathBuf, ()>,
 }
 
+#[derive(Debug)]
+struct FileFixApplication {
+	changed_files: Vec<PathBuf>,
+	total_applied: usize,
+	import_fallbacks: BTreeMap<PathBuf, ImportFallbackPlan>,
+	changed_originals: BTreeMap<PathBuf, (PathBuf, String)>,
+	let_mut_reorder_files: BTreeMap<PathBuf, ()>,
+	type_alias_rename_files: BTreeMap<PathBuf, ()>,
+}
+
 pub(crate) fn run_check(cargo_options: &CargoOptions) -> Result<RunSummary> {
 	let (summary, _state) = run_check_with_state(cargo_options)?;
 
@@ -128,7 +139,7 @@ pub(crate) fn run_fix(
 ) -> Result<RunSummary> {
 	semantic::reset_cache_stats();
 
-	let (initial_checked, mut check_state) = run_check_with_state(cargo_options)?;
+	let (initial_checked, mut check_state) = run_initial_check(cargo_options, progress)?;
 	let mut total_applied = 0_usize;
 	let mut previous_fixable_count = check_state.fixable_count();
 
@@ -207,7 +218,7 @@ pub(crate) fn run_fix(
 		previous_fixable_count = fixable_count;
 	}
 
-	let mut checked = if total_applied > 0 { run_check(cargo_options)? } else { initial_checked };
+	let mut checked = run_final_check(cargo_options, initial_checked, total_applied, progress)?;
 
 	checked.applied_fix_count = total_applied;
 
@@ -228,6 +239,70 @@ pub(crate) fn print_coverage() {
 	for rule in STYLE_RULE_IDS {
 		println!("{rule}\timplemented");
 	}
+}
+
+fn run_initial_check(
+	cargo_options: &CargoOptions,
+	progress: bool,
+) -> Result<(RunSummary, CheckState)> {
+	if progress {
+		eprintln!("vstyle tune: starting initial scan.");
+	}
+
+	let started = Instant::now();
+	let (summary, state) = run_check_with_state(cargo_options)?;
+
+	if progress {
+		eprintln!(
+			"vstyle tune: initial scan checked {} file(s), found {} violation(s), {} fixable, {} manual ({}).",
+			summary.file_count,
+			summary.violation_count,
+			state.fixable_count(),
+			summary.unfixable_count,
+			format_duration(started.elapsed()),
+		);
+	}
+
+	Ok((summary, state))
+}
+
+fn run_final_check(
+	cargo_options: &CargoOptions,
+	initial_checked: RunSummary,
+	total_applied: usize,
+	progress: bool,
+) -> Result<RunSummary> {
+	if total_applied == 0 {
+		return Ok(initial_checked);
+	}
+	if progress {
+		eprintln!("vstyle tune: starting final scan.");
+	}
+
+	let started = Instant::now();
+	let checked = run_check(cargo_options)?;
+
+	if progress {
+		eprintln!(
+			"vstyle tune: final scan checked {} file(s), found {} remaining violation(s), {} manual ({}).",
+			checked.file_count,
+			checked.violation_count,
+			checked.unfixable_count,
+			format_duration(started.elapsed()),
+		);
+	}
+
+	Ok(checked)
+}
+
+fn format_duration(duration: Duration) -> String {
+	let millis = duration.as_millis();
+
+	if millis < 1_000 {
+		return format!("{millis}ms");
+	}
+
+	format!("{}.{:03}s", millis / 1_000, millis % 1_000)
 }
 
 fn run_check_with_state(cargo_options: &CargoOptions) -> Result<(RunSummary, CheckState)> {
@@ -389,97 +464,80 @@ fn run_fix_round(
 	}
 
 	let round_start_snapshot = collect_file_snapshots(files);
-	let type_alias_plan = collect_type_alias_rename_plan(files)?;
-	let outcomes_all = collect_fix_outcomes(files, &type_alias_plan)?;
-	let changed_files = changed_file_paths(&outcomes_all);
-	let mut total_applied = outcomes_all.iter().map(|outcome| outcome.applied_count).sum::<usize>();
-	let mut import_fallbacks: BTreeMap<PathBuf, ImportFallbackPlan> = BTreeMap::new();
-	let mut changed_originals: BTreeMap<PathBuf, (PathBuf, String)> = BTreeMap::new();
-	let mut let_mut_reorder_files: BTreeMap<PathBuf, ()> = BTreeMap::new();
-	let mut type_alias_rename_files: BTreeMap<PathBuf, ()> = BTreeMap::new();
+	let mut file_fixes = collect_and_apply_file_fixes(files, &scope_label, progress)?;
 
-	for outcome in outcomes_all {
-		if let Some(text) = outcome.rewritten_text {
-			fs::write(&outcome.path, text)?;
-		}
-		if let Some(original_text) = outcome.original_text {
-			changed_originals
-				.insert(normalize_path(&outcome.path), (outcome.path.clone(), original_text));
-		}
-		if let Some(source_text) = outcome.import_fallback_source_text {
-			let normalized = normalize_path(&outcome.path);
-
-			import_fallbacks
-				.insert(normalized, ImportFallbackPlan { path: outcome.path.clone(), source_text });
-		}
-
-		if outcome.had_let_mut_reorder_edits {
-			let_mut_reorder_files.insert(normalize_path(&outcome.path), ());
-		}
-		if outcome.had_type_alias_rename_edits {
-			type_alias_rename_files.insert(normalize_path(&outcome.path), ());
-		}
-	}
-
-	if changed_files.is_empty() {
+	if file_fixes.changed_files.is_empty() {
 		if progress {
-			eprintln!("vstyle tune: [{scope_label}] applied {} fix(es) this round.", total_applied);
+			eprintln!(
+				"vstyle tune: [{scope_label}] applied {} fix(es) this round.",
+				file_fixes.total_applied
+			);
 		}
 
 		return Ok(FixRoundSummary::default());
 	}
 
-	let semantic_cargo_options = scoped_semantic_cargo_options(cargo_options, &changed_files)?;
+	let semantic_cargo_options =
+		scoped_semantic_cargo_options(cargo_options, &file_fixes.changed_files)?;
 
 	if progress {
 		eprintln!("vstyle tune: [{scope_label}] running semantic validation.");
 	}
 
+	let semantic_started = Instant::now();
 	let (baseline_stdout, baseline_error_files) =
 		semantic::collect_compiler_error_files_with_output(
-			&changed_files,
+			&file_fixes.changed_files,
 			&semantic_cargo_options,
 			verbose,
 			progress,
 		)?;
-	let semantic_phase_start_snapshot = collect_file_snapshots(&changed_files);
+	let semantic_phase_start_snapshot = collect_file_snapshots(&file_fixes.changed_files);
 	let semantic_applied = semantic::apply_semantic_fixes(
-		&changed_files,
+		&file_fixes.changed_files,
 		&semantic_cargo_options,
 		Some(baseline_stdout),
 		verbose,
 		progress,
 	)?;
 
-	total_applied += semantic_applied;
+	file_fixes.total_applied += semantic_applied;
 
+	if progress {
+		eprintln!(
+			"vstyle tune: [{scope_label}] semantic validation found {} baseline error file(s) and applied {} import fix(es) ({}).",
+			baseline_error_files.len(),
+			semantic_applied,
+			format_duration(semantic_started.elapsed()),
+		);
+	}
 	if semantic_applied > 0 {
-		total_applied += apply_post_semantic_cleanup(
-			&changed_files,
+		file_fixes.total_applied += apply_post_semantic_cleanup(
+			&file_fixes.changed_files,
 			&semantic_phase_start_snapshot,
-			&mut import_fallbacks,
-			&mut changed_originals,
-			&mut let_mut_reorder_files,
+			&mut file_fixes.import_fallbacks,
+			&mut file_fixes.changed_originals,
+			&mut file_fixes.let_mut_reorder_files,
 		)?;
 	}
 
 	handle_semantic_validation_fallbacks(SemanticValidationFallbacks {
-		files: &changed_files,
+		files: &file_fixes.changed_files,
 		semantic_cargo_options: &semantic_cargo_options,
 		baseline_error_files: &baseline_error_files,
 		post_error_files: (semantic_applied == 0).then_some(&baseline_error_files),
 		verbose,
 		progress,
-		import_fallbacks: &import_fallbacks,
-		changed_originals: &changed_originals,
-		let_mut_reorder_files: &let_mut_reorder_files,
-		type_alias_rename_files: &type_alias_rename_files,
+		import_fallbacks: &file_fixes.import_fallbacks,
+		changed_originals: &file_fixes.changed_originals,
+		let_mut_reorder_files: &file_fixes.let_mut_reorder_files,
+		type_alias_rename_files: &file_fixes.type_alias_rename_files,
 	})?;
 
 	let net_changed_files = changed_files_since_snapshot(&round_start_snapshot);
 
 	// Count this round as no-op when all edits are eventually rolled back.
-	if total_applied > 0 && net_changed_files.is_empty() {
+	if file_fixes.total_applied > 0 && net_changed_files.is_empty() {
 		return Ok(FixRoundSummary::default());
 	}
 
@@ -490,14 +548,84 @@ fn run_fix_round(
 	};
 
 	if progress {
-		eprintln!("vstyle tune: [{scope_label}] applied {} fix(es) this round.", total_applied);
+		eprintln!(
+			"vstyle tune: [{scope_label}] applied {} fix(es) this round across {} net changed file(s).",
+			file_fixes.total_applied,
+			net_changed_files.len(),
+		);
 	}
 
 	Ok(FixRoundSummary {
-		applied_count: total_applied,
+		applied_count: file_fixes.total_applied,
 		requires_follow_up_round,
 		changed_files: net_changed_files,
 	})
+}
+
+fn collect_and_apply_file_fixes(
+	files: &[PathBuf],
+	scope_label: &str,
+	progress: bool,
+) -> Result<FileFixApplication> {
+	let collect_started = Instant::now();
+	let type_alias_plan = collect_type_alias_rename_plan(files)?;
+	let outcomes_all = collect_fix_outcomes(files, &type_alias_plan, scope_label, progress)?;
+	let changed_files = changed_file_paths(&outcomes_all);
+	let total_applied = outcomes_all.iter().map(|outcome| outcome.applied_count).sum::<usize>();
+
+	if progress {
+		eprintln!(
+			"vstyle tune: [{scope_label}] collected {} fix(es) across {} changed file(s) ({}).",
+			total_applied,
+			changed_files.len(),
+			format_duration(collect_started.elapsed()),
+		);
+	}
+
+	let mut application = FileFixApplication {
+		changed_files,
+		total_applied,
+		import_fallbacks: BTreeMap::new(),
+		changed_originals: BTreeMap::new(),
+		let_mut_reorder_files: BTreeMap::new(),
+		type_alias_rename_files: BTreeMap::new(),
+	};
+
+	for outcome in outcomes_all {
+		apply_file_fix_outcome(outcome, &mut application)?;
+	}
+
+	Ok(application)
+}
+
+fn apply_file_fix_outcome(
+	outcome: FileFixOutcome,
+	application: &mut FileFixApplication,
+) -> Result<()> {
+	if let Some(text) = outcome.rewritten_text {
+		fs::write(&outcome.path, text)?;
+	}
+	if let Some(original_text) = outcome.original_text {
+		application
+			.changed_originals
+			.insert(normalize_path(&outcome.path), (outcome.path.clone(), original_text));
+	}
+	if let Some(source_text) = outcome.import_fallback_source_text {
+		let normalized = normalize_path(&outcome.path);
+
+		application
+			.import_fallbacks
+			.insert(normalized, ImportFallbackPlan { path: outcome.path.clone(), source_text });
+	}
+
+	if outcome.had_let_mut_reorder_edits {
+		application.let_mut_reorder_files.insert(normalize_path(&outcome.path), ());
+	}
+	if outcome.had_type_alias_rename_edits {
+		application.type_alias_rename_files.insert(normalize_path(&outcome.path), ());
+	}
+
+	Ok(())
 }
 
 fn fix_scope_label(cargo_options: &CargoOptions) -> String {
@@ -767,10 +895,15 @@ fn apply_type_alias_rename_plan(
 fn collect_fix_outcomes(
 	files: &[PathBuf],
 	type_alias_plan: &TypeAliasRenamePlan,
+	scope_label: &str,
+	progress: bool,
 ) -> Result<Vec<FileFixOutcome>> {
+	let batch_count = files.len().div_ceil(FILE_BATCH_SIZE);
 	let mut outcomes_all = Vec::<FileFixOutcome>::new();
+	let mut processed = 0_usize;
 
-	for batch in files.chunks(FILE_BATCH_SIZE) {
+	for (batch_idx, batch) in files.chunks(FILE_BATCH_SIZE).enumerate() {
+		let batch_started = Instant::now();
 		let outcomes = batch
 			.par_iter()
 			.map(|file| -> Result<FileFixOutcome> {
@@ -808,9 +941,34 @@ fn collect_fix_outcomes(
 				})
 			})
 			.collect::<Vec<_>>();
+		let mut batch_applied = 0_usize;
+		let mut batch_changed = 0_usize;
 
 		for outcome in outcomes {
-			outcomes_all.push(outcome?);
+			let outcome = outcome?;
+
+			batch_applied += outcome.applied_count;
+
+			if outcome.rewritten_text.is_some() {
+				batch_changed += 1;
+			}
+
+			outcomes_all.push(outcome);
+		}
+
+		processed += batch.len();
+
+		if progress && batch_count > 1 {
+			eprintln!(
+				"vstyle tune: [{scope_label}] fix scan batch {}/{} checked {}/{} file(s), changed {}, found {} fix(es) ({}).",
+				batch_idx + 1,
+				batch_count,
+				processed,
+				files.len(),
+				batch_changed,
+				batch_applied,
+				format_duration(batch_started.elapsed()),
+			);
 		}
 	}
 
@@ -2356,6 +2514,8 @@ use crate::z::Z;
 		let outcomes = super::collect_fix_outcomes(
 			slice::from_ref(&path),
 			&super::TypeAliasRenamePlan::default(),
+			"test",
+			false,
 		)
 		.expect("collect fix outcomes");
 		let outcome = outcomes.first().expect("one outcome");

--- a/src/style/imports.rs
+++ b/src/style/imports.rs
@@ -277,24 +277,29 @@ fn apply_import012_crate_keep_alive_rule(
 	use_item_analyses: &[UseItemAnalysis<'_>],
 	local_module_roots: &HashSet<String>,
 ) {
-	let package_contexts = shared::package_rust_files_for_path(&ctx.path).ok().flatten().map(
-		|(current_path, package_files)| {
-			package_files
-				.into_iter()
-				.filter(|path| *path != current_path)
-				.filter_map(|path| shared::read_file_context(&path).ok().flatten())
-				.collect::<Vec<_>>()
-		},
-	);
+	let keep_alive_imports = use_item_analyses
+		.iter()
+		.filter_map(|use_item_analysis| {
+			import012_keep_alive_root(&use_item_analysis.path, local_module_roots)
+				.map(|root| (use_item_analysis.item, root))
+		})
+		.collect::<Vec<_>>();
 
-	for use_item_analysis in use_item_analyses {
-		let item = use_item_analysis.item;
-		let Some(root) = import012_keep_alive_root(&use_item_analysis.path, local_module_roots)
-		else {
+	if keep_alive_imports.is_empty() {
+		return;
+	}
+
+	let mut package_contexts = None;
+
+	for (item, root) in keep_alive_imports {
+		if import012_context_mentions_root(ctx, Some(item.start_offset), root.as_str()) {
 			continue;
-		};
+		}
 
-		if import012_has_other_root_usage(ctx, item, root.as_str(), package_contexts.as_deref()) {
+		let package_contexts =
+			package_contexts.get_or_insert_with(|| import012_package_contexts(ctx));
+
+		if import012_package_contexts_mention_root(package_contexts, root.as_str()) {
 			continue;
 		}
 
@@ -307,6 +312,20 @@ fn apply_import012_crate_keep_alive_rule(
 			false,
 		);
 	}
+}
+
+fn import012_package_contexts(ctx: &FileContext) -> Vec<FileContext> {
+	shared::package_rust_files_for_path(&ctx.path)
+		.ok()
+		.flatten()
+		.map(|(current_path, package_files)| {
+			package_files
+				.into_iter()
+				.filter(|path| *path != current_path)
+				.filter_map(|path| shared::read_file_context(&path).ok().flatten())
+				.collect::<Vec<_>>()
+		})
+		.unwrap_or_default()
 }
 
 fn import012_keep_alive_root(path: &str, local_module_roots: &HashSet<String>) -> Option<String> {
@@ -336,25 +355,10 @@ fn import012_keep_alive_root(path: &str, local_module_roots: &HashSet<String>) -
 	Some(base.to_owned())
 }
 
-fn import012_has_other_root_usage(
-	ctx: &FileContext,
-	current_item: &TopItem,
-	root: &str,
-	package_contexts: Option<&[FileContext]>,
-) -> bool {
-	if import012_context_mentions_root(ctx, Some(current_item.start_offset), root) {
-		return true;
-	}
-
-	if let Some(package_contexts) = package_contexts {
-		for package_ctx in package_contexts {
-			if import012_context_mentions_root(package_ctx, None, root) {
-				return true;
-			}
-		}
-	}
-
-	false
+fn import012_package_contexts_mention_root(package_contexts: &[FileContext], root: &str) -> bool {
+	package_contexts
+		.iter()
+		.any(|package_ctx| import012_context_mentions_root(package_ctx, None, root))
 }
 
 fn import012_context_mentions_root(

--- a/tests/let_mut_reorder.rs
+++ b/tests/let_mut_reorder.rs
@@ -93,6 +93,26 @@ pub fn closure_carries_binding() {
 	assert!(safe_immutable_pos < safe_mut_pos);
 	assert_eq!(unsafe_after, unsafe_source);
 	assert!(
+		stderr.contains("vstyle tune: starting initial scan."),
+		"expected initial scan telemetry on captured stderr:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("vstyle tune: initial scan checked"),
+		"expected initial scan summary telemetry on captured stderr:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("vstyle tune: round 1/"),
+		"expected fix round telemetry on captured stderr:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("vstyle tune: starting final scan."),
+		"expected final scan start telemetry on captured stderr:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("vstyle tune: final scan checked"),
+		"expected final scan summary telemetry on captured stderr:\n{stderr}"
+	);
+	assert!(
 		!stderr.contains("Skipped RUST-STYLE-LET-001 reorder in"),
 		"did not expect a semantic validation skip diagnostic for the unfixable fixture"
 	);


### PR DESCRIPTION
## Summary
- Avoid eager package-wide IMPORT-012 context parsing when no crate keep-alive imports exist
- Emit tune progress telemetry to stderr even when redirected
- Bump release version to v0.2.2 and document telemetry behavior

## Validation
- cargo make check
- Decodex workspace performance: curate improved from about 70.92s to about 8-10s; tune --strict completed with progress telemetry where the old run was interrupted after about 393.94s without visible progress

Authority: XY-1148