### PR TITLE
Harden vstyle fixers and optimize CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,25 +28,11 @@ concurrency:
 
 jobs:
   benchmark:
-    name: ${{ matrix.name }}
+    name: Benchmark suite
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - key: release
-            name: Release benchmark
-            task: bench-release-vstyle
-            summary_glob: target/vstyle-bench/*/summary.txt
-            artifact_path: target/vstyle-bench
-          - key: semantic
-            name: Semantic benchmark
-            task: bench-semantic-vstyle
-            summary_glob: target/vstyle-bench-semantic/*/summary.txt
-            artifact_path: target/vstyle-bench-semantic
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -55,37 +41,83 @@ jobs:
           rustflags: ''
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: cargo-make
 
-      - name: Run benchmark
-        run: cargo make ${{ matrix.task }}
+      - name: Run release benchmark
+        id: release-benchmark
+        continue-on-error: true
+        run: cargo make bench-release-vstyle
 
-      - name: Publish benchmark summary
+      - name: Run semantic benchmark
+        id: semantic-benchmark
+        continue-on-error: true
+        run: cargo make bench-semantic-vstyle
+
+      - name: Publish release benchmark summary
+        if: steps.release-benchmark.outcome == 'success'
         shell: bash
         run: |
           set -euo pipefail
 
-          summary_file="$(find . -path "./${{ matrix.summary_glob }}" -type f | sort | tail -n 1)"
+          summary_file="$(find . -path './target/vstyle-bench/*/summary.txt' -type f | sort | tail -n 1)"
 
           if [[ -z "${summary_file}" ]]; then
-            printf 'Missing summary file for %s\n' "${{ matrix.name }}" >&2
+            printf 'Missing release benchmark summary file\n' >&2
             exit 1
           fi
 
           {
-            printf "## %s\n\n" "${{ matrix.name }}"
+            printf '## Release benchmark\n\n'
             printf "Summary file: \`%s\`\n\n" "${summary_file#./}"
             printf "%s\n" '```text'
             cat "${summary_file}"
             printf "%s\n" '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload benchmark artifacts
+      - name: Upload release benchmark artifacts
+        if: steps.release-benchmark.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmarks-${{ matrix.key }}-${{ github.run_number }}-${{ github.run_attempt }}
-          path: ${{ matrix.artifact_path }}
+          name: benchmarks-release-${{ github.run_number }}-${{ github.run_attempt }}
+          path: target/vstyle-bench
           if-no-files-found: error
           retention-days: 14
+
+      - name: Publish semantic benchmark summary
+        if: steps.semantic-benchmark.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          summary_file="$(find . -path './target/vstyle-bench-semantic/*/summary.txt' -type f | sort | tail -n 1)"
+
+          if [[ -z "${summary_file}" ]]; then
+            printf 'Missing semantic benchmark summary file\n' >&2
+            exit 1
+          fi
+
+          {
+            printf '## Semantic benchmark\n\n'
+            printf "Summary file: \`%s\`\n\n" "${summary_file#./}"
+            printf "%s\n" '```text'
+            cat "${summary_file}"
+            printf "%s\n" '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload semantic benchmark artifacts
+        if: steps.semantic-benchmark.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmarks-semantic-${{ github.run_number }}-${{ github.run_attempt }}
+          path: target/vstyle-bench-semantic
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Require both benchmarks to pass
+        if: >-
+          always() &&
+          (steps.release-benchmark.outcome != 'success' ||
+          steps.semantic-benchmark.outcome != 'success')
+        run: exit 1

--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -31,7 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install taplo
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+        with:
+          tool: taplo
+
+      - name: Run TOML format check
+        run: taplo fmt --check
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -44,25 +52,17 @@ jobs:
         run: rustup toolchain install nightly --component rustfmt
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: cargo-make
 
       - name: Install nextest
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: nextest
 
       - name: Run Rust format check
         run: cargo make fmt-rust-check
-
-      - name: Run Rust style check
-        uses: ./
-        with:
-          language: rust
-          workspace: true
-          args: --all-features
-          version: checkout
 
       - name: Run Rust clippy
         run: cargo make check-rust
@@ -70,28 +70,7 @@ jobs:
       - name: Run tests
         run: cargo make test-rust
 
-  toml-check:
-    name: TOML check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch latest code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          cache: true
-          rustflags: ''
-
-      - name: Install cargo-make
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
-        with:
-          tool: cargo-make
-
-      - name: Install taplo
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
-        with:
-          tool: taplo
-
-      - name: Run TOML format check
-        run: cargo make fmt-toml-check
+      - name: Run Rust style check
+        run: >-
+          cargo run --locked --all-features --bin vstyle --
+          curate --language rust --workspace --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -32,7 +32,7 @@ jobs:
           ]
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -88,6 +88,8 @@ jobs:
     name: Publish binary release
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -98,19 +100,35 @@ jobs:
           mv vibe-style-*/* artifacts/
 
       - name: Publish
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
           files: artifacts/*
 
+  action-smoke:
+    name: Verify released GitHub Action
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - name: Fetch released code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run released action
+        uses: ./
+        with:
+          language: rust
+          workspace: true
+          args: --all-features
+          version: ${{ github.ref_name }}
+
   publish-on-crates-io:
     name: Publish on crates.io
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [action-smoke]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -125,14 +125,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -140,15 +140,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -185,15 +185,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -213,14 +213,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -270,18 +270,18 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -289,18 +289,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "darling"
@@ -322,7 +322,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -350,9 +350,9 @@ checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "eyre"
@@ -402,9 +402,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -429,15 +429,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -527,32 +527,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.165.0"
+version = "0.166.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7c9cc05e0e6b72a214a455a106d9b22b0494164d50a657b17bd319534c218"
+checksum = "527c12b3731b7d0692498012810b85b2b8dfdb8b514321ed6afc434bd1c70191"
 dependencies = [
  "memchr",
  "unicode-ident",
@@ -561,15 +561,15 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_edition"
-version = "0.0.340"
+version = "0.0.346"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8673a45b7b87d5050ed014479ec79478626d160ec7aaf0c92a9abf6a0cb4c800"
+checksum = "c9783aa966d3a19c3a407babeb331ee4370f0aaa4a23646ab9bb45ba8a3a9dc2"
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.340"
+version = "0.0.346"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5922a9e799961d31590f61f0652991fb6260310d7d2095457240232a57b6010e"
+checksum = "bbf11eb1b46bbba8aa1767436791234500562204c25654cc03900ffd043963a0"
 dependencies = [
  "drop_bomb",
  "ra-ap-rustc_lexer",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.340"
+version = "0.0.346"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2531000f8154631a77aa3f614b9c6abbed2bfb7f97b7876c71c1d7a50a6b755d"
+checksum = "1d1462ef1865500b292afd582af8de4661fce3986a7c4e94cdd5ce46ae5252f9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
@@ -597,16 +597,17 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.340"
+version = "0.0.346"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84aac5ca5804e576e84ba8f681be18e78d6ad0eed2c87d16edc1fbc259721a32"
+checksum = "fa4b3e65ef77b752447610921a6d87d2a1e64ea3ab744b049467949302fa0f44"
 dependencies = [
  "either",
  "itertools",
+ "ra-ap-rustc_lexer",
  "ra_ap_parser",
  "ra_ap_stdx",
  "rowan",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustc-literal-escaper",
  "smallvec",
  "smol_str",
@@ -636,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -648,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -665,9 +666,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rowan"
-version = "0.15.18"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+checksum = "14b574c58582fa59fa43a2feb6608b8744184659f08a2e0117e4b8224d95ed61"
 dependencies = [
  "countme",
  "hashbrown",
@@ -678,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -690,9 +691,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-literal-escaper"
@@ -702,9 +703,9 @@ checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "semver"
@@ -718,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -728,29 +729,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -792,9 +793,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -809,38 +821,38 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -860,9 +872,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -941,9 +953,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vergen"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
+checksum = "3fd02b50246a773d6b8f48cf8e4e623a2773fd31cbe697bf10289abbb17e9e87"
 dependencies = [
  "anyhow",
  "bon",
@@ -953,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-gitcl"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d9fead6d7c515ac3a658e1a65d36925525d5cfdea414e27eb99b99ffd92bfa"
+checksum = "ec10aaab7eb8907a2d9a12dad532b0a317955f5c3837c04cf6f47bb5c16ebe97"
 dependencies = [
  "anyhow",
  "bon",
@@ -967,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
+checksum = "7d6a4e23de0fd3f8a940650a4d83eca980e9ef8f108fe6ddeb5313b0313523d3"
 dependencies = [
  "anyhow",
  "bon",
@@ -1013,6 +1025,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ vergen-gitcl = { version = "10.0", features = ["cargo"] }
 cargo_metadata = { version = "0.23" }
 clap           = { version = "4.6", features = ["derive"] }
 color-eyre     = { version = "0.6" }
-ra_ap_syntax   = { version = "0.0.340" }
+ra_ap_syntax   = { version = "0.0.346" }
 rayon          = { version = "1.12" }
-regex          = { version = "1.12" }
+regex          = { version = "1.13" }
 serde_json     = { version = "1.0" }

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ vstyle tune --language rust -p api --all-features --no-default-features
 - `tune`
   - Exit `0`: even if unresolved violations remain.
   - Exit `1`: unresolved violations remain and `--strict` is used.
+  - Internal fix or semantic-validation error: restore all selected source files to their
+    start-of-command contents, then return a failure.
 
 Use `--language rust` to check Rust files and `--language swift` to check Swift files.
 File discovery scans every selected `*.rs` or `*.swift` file that is not matched by Git ignore
@@ -202,9 +204,11 @@ from the Cargo workspace root.
 
 ### CI policy
 
-CI runs the checked-out action for Rust read-only style verification to keep feedback fast and
-deterministic. Use `vstyle tune` locally when you want to apply safe automatic fixes (for example,
-via `cargo make lint`).
+CI runs the current checkout directly for Rust read-only style verification so the style gate can
+reuse the same Cargo build graph as Clippy and tests. The release workflow then runs the composite
+action against the exact tag and newly published binary asset before it publishes the crate to
+crates.io. Use `vstyle tune` locally when you want to apply safe automatic fixes (for example, via
+`cargo make lint`).
 
 ### Release benchmark
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -32,6 +32,8 @@ Question this index answers: "what must remain true?"
   derive-related import rules.
 - `docs/spec/swift_style_rule_applicability.md`: Swift applicability, first-batch Swift rules,
   and Rust-only rule boundaries.
+- `docs/spec/tune_failure_atomicity.md`: semantic commit conditions and rollback behavior for
+  failed `vstyle tune` runs.
 
 ## Spec document contract
 

--- a/docs/spec/style_rule_backends.md
+++ b/docs/spec/style_rule_backends.md
@@ -70,7 +70,6 @@ AST-backed rules (some may also use limited text for replacement formatting):
 
 Layout-backed rules (source-text driven by design):
 
-- `RUST-STYLE-SPACE-003`
 - `RUST-STYLE-SPACE-004`
 
 Hybrid AST-backed + layout-backed rules (AST classification plus line-aware spacing or reorder planning):
@@ -81,10 +80,15 @@ Hybrid AST-backed + layout-backed rules (AST classification plus line-aware spac
 - `RUST-STYLE-MOD-005`
 - `RUST-STYLE-IMPL-001`
 - `RUST-STYLE-IMPL-003`
+- `RUST-STYLE-SPACE-003` (AST control-flow boundaries plus line-aware statement spacing)
 
 Semantic-backed rules:
 
-- `RUST-STYLE-LET-001` (AST edit generation with compiler-error diff validation during `tune`)
+- `RUST-STYLE-LET-001` (AST literal-initializer safety proof and edit generation, with
+  compiler-error diff validation during `tune`)
+
+`RUST-STYLE-LET-001` reports an ordering violation without an automatic fix when initializer or
+binding-shadowing safety is not proven.
 
 Swift source-text-backed rules:
 

--- a/docs/spec/tune_failure_atomicity.md
+++ b/docs/spec/tune_failure_atomicity.md
@@ -1,0 +1,48 @@
+# Tune Failure Atomicity
+
+Purpose: Define when `vstyle tune` may keep edits and when it must restore source files.
+
+Status: normative
+
+Read this when:
+
+- You change fix-round writes, semantic validation, fallback behavior, or tune error handling.
+- You need to determine whether a failed tune command may leave source edits on disk.
+
+Not this document:
+
+- This document does not define style rule semantics.
+- This document does not guarantee recovery after process termination, power loss, or storage
+  failure.
+
+Defines:
+
+- The semantic commit condition for automatic fixes.
+- The rollback boundary for errors returned by `vstyle tune`.
+
+## Commit condition
+
+- Before a planned fix batch writes files, its Cargo scope must produce a successful
+  `build-finished` result.
+- After edits and any semantic import recovery, the Cargo scope must produce a successful
+  `build-finished` result.
+- A failed Cargo command without file-scoped compiler diagnostics is still a semantic validation
+  failure.
+
+## Rollback boundary
+
+- `vstyle tune` snapshots all selected source files at the start of the command.
+- If the command returns an internal error after a source write, it restores every selected source
+  file to its start-of-command contents.
+- The command returns the original error after a successful rollback.
+- If rollback also fails, the command reports both the original error and the rollback error.
+- Package-scoped fix rounds may use narrower fallback edits before final validation. The command
+  commits those edits only when the final semantic result succeeds.
+
+The whole-command boundary is required because one edit can cause a compiler error in another
+file. A compiler diagnostic's primary file is not sufficient proof of which edit caused the error.
+
+## Non-error strict results
+
+A completed `tune --strict` run can return a non-zero exit code because style violations remain.
+This result is not an internal tune error. Semantically validated edits remain on disk.

--- a/src/style.rs
+++ b/src/style.rs
@@ -22,7 +22,7 @@ use std::{
 	time::{Duration, Instant},
 };
 
-use color_eyre::Result;
+use color_eyre::{Result, eyre};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use semantic::SemanticCacheStats;
@@ -126,10 +126,27 @@ struct FileFixApplication {
 	type_alias_rename_files: BTreeMap<PathBuf, ()>,
 }
 
+#[derive(Debug)]
+struct CollectedFileFixes {
+	outcomes: Vec<FileFixOutcome>,
+	changed_files: Vec<PathBuf>,
+	total_applied: usize,
+}
+
 pub(crate) fn run_check(cargo_options: &CargoOptions) -> Result<RunSummary> {
 	let (summary, _state) = run_check_with_state(cargo_options)?;
 
 	Ok(summary)
+}
+
+pub(crate) fn semantic_cache_stats() -> SemanticCacheStats {
+	semantic::cache_stats()
+}
+
+pub(crate) fn print_coverage() {
+	for rule in STYLE_RULE_IDS {
+		println!("{rule}\timplemented");
+	}
 }
 
 pub(crate) fn run_fix(
@@ -139,6 +156,40 @@ pub(crate) fn run_fix(
 ) -> Result<RunSummary> {
 	semantic::reset_cache_stats();
 
+	let files = shared::resolve_files(cargo_options)?;
+	let run_start_snapshot = collect_file_snapshots(&files);
+	let result = run_fix_inner(cargo_options, verbose, progress);
+
+	match result {
+		Ok(summary) => Ok(summary),
+		Err(error) => {
+			let changed_files = changed_files_since_snapshot(&run_start_snapshot);
+
+			if changed_files.is_empty() {
+				return Err(error);
+			}
+
+			if let Err(rollback_error) = restore_file_snapshots(&run_start_snapshot) {
+				return Err(eyre::eyre!(
+					"vstyle tune failed and rollback also failed. Original error: {error:?}. Rollback error: {rollback_error:?}."
+				));
+			}
+
+			eprintln!(
+				"vstyle tune: rolled back {} file(s) because the run failed.",
+				changed_files.len()
+			);
+
+			Err(error)
+		},
+	}
+}
+
+fn run_fix_inner(
+	cargo_options: &CargoOptions,
+	verbose: bool,
+	progress: bool,
+) -> Result<RunSummary> {
 	let (initial_checked, mut check_state) = run_initial_check(cargo_options, progress)?;
 	let mut total_applied = 0_usize;
 	let mut previous_fixable_count = check_state.fixable_count();
@@ -229,16 +280,6 @@ pub(crate) fn run_fix(
 		applied_fix_count: total_applied,
 		output_lines: checked.output_lines,
 	})
-}
-
-pub(crate) fn semantic_cache_stats() -> SemanticCacheStats {
-	semantic::cache_stats()
-}
-
-pub(crate) fn print_coverage() {
-	for rule in STYLE_RULE_IDS {
-		println!("{rule}\timplemented");
-	}
 }
 
 fn run_initial_check(
@@ -451,52 +492,59 @@ fn fix_scope_files_are_disjoint(fix_round_scopes: &[FixRoundScope]) -> bool {
 	true
 }
 
-fn run_fix_round(
+fn validate_pre_edit_semantic_baseline(
 	files: &[PathBuf],
 	cargo_options: &CargoOptions,
+	scope_label: &str,
 	verbose: bool,
 	progress: bool,
-) -> Result<FixRoundSummary> {
-	let scope_label = fix_scope_label(cargo_options);
-
+) -> Result<BTreeSet<PathBuf>> {
 	if progress {
-		eprintln!("vstyle tune: [{scope_label}] collecting fixes for {} file(s).", files.len());
+		eprintln!("vstyle tune: [{scope_label}] validating the pre-edit semantic baseline.");
 	}
 
-	let round_start_snapshot = collect_file_snapshots(files);
-	let mut file_fixes = collect_and_apply_file_fixes(files, &scope_label, progress)?;
+	let (stdout, error_files) = semantic::collect_compiler_error_files_with_output(
+		files,
+		cargo_options,
+		verbose,
+		progress,
+	)?;
 
-	if file_fixes.changed_files.is_empty() {
-		if progress {
-			eprintln!(
-				"vstyle tune: [{scope_label}] applied {} fix(es) this round.",
-				file_fixes.total_applied
-			);
-		}
-
-		return Ok(FixRoundSummary::default());
+	if semantic::semantic_check_succeeded(&stdout) != Some(true) {
+		return Err(eyre::eyre!(
+			"vstyle tune: [{scope_label}] pre-edit semantic validation failed; no fixes were written."
+		));
 	}
 
-	let semantic_cargo_options =
-		scoped_semantic_cargo_options(cargo_options, &file_fixes.changed_files)?;
+	Ok(error_files)
+}
 
+fn apply_semantic_validation(
+	scope_label: &str,
+	file_fixes: &mut FileFixApplication,
+	cargo_options: &CargoOptions,
+	baseline_error_files: &BTreeSet<PathBuf>,
+	verbose: bool,
+	progress: bool,
+) -> Result<usize> {
 	if progress {
-		eprintln!("vstyle tune: [{scope_label}] running semantic validation.");
+		eprintln!("vstyle tune: [{scope_label}] validating the edited files.");
 	}
 
 	let semantic_started = Instant::now();
-	let (baseline_stdout, baseline_error_files) =
+	let (post_edit_stdout, post_edit_error_files) =
 		semantic::collect_compiler_error_files_with_output(
 			&file_fixes.changed_files,
-			&semantic_cargo_options,
+			cargo_options,
 			verbose,
 			progress,
 		)?;
+	let post_edit_succeeded = semantic::semantic_check_succeeded(&post_edit_stdout) == Some(true);
 	let semantic_phase_start_snapshot = collect_file_snapshots(&file_fixes.changed_files);
 	let semantic_applied = semantic::apply_semantic_fixes(
 		&file_fixes.changed_files,
-		&semantic_cargo_options,
-		Some(baseline_stdout),
+		cargo_options,
+		Some(post_edit_stdout),
 		verbose,
 		progress,
 	)?;
@@ -505,8 +553,8 @@ fn run_fix_round(
 
 	if progress {
 		eprintln!(
-			"vstyle tune: [{scope_label}] semantic validation found {} baseline error file(s) and applied {} import fix(es) ({}).",
-			baseline_error_files.len(),
+			"vstyle tune: [{scope_label}] semantic validation found {} post-edit error file(s) and applied {} import fix(es) ({}).",
+			post_edit_error_files.len(),
 			semantic_applied,
 			format_duration(semantic_started.elapsed()),
 		);
@@ -523,9 +571,9 @@ fn run_fix_round(
 
 	handle_semantic_validation_fallbacks(SemanticValidationFallbacks {
 		files: &file_fixes.changed_files,
-		semantic_cargo_options: &semantic_cargo_options,
-		baseline_error_files: &baseline_error_files,
-		post_error_files: (semantic_applied == 0).then_some(&baseline_error_files),
+		semantic_cargo_options: cargo_options,
+		baseline_error_files,
+		post_error_files: (semantic_applied == 0).then_some(&post_edit_error_files),
 		verbose,
 		progress,
 		import_fallbacks: &file_fixes.import_fallbacks,
@@ -534,6 +582,69 @@ fn run_fix_round(
 		type_alias_rename_files: &file_fixes.type_alias_rename_files,
 	})?;
 
+	if semantic_applied > 0 || !post_edit_succeeded {
+		let (final_stdout, _final_error_files) =
+			semantic::collect_compiler_error_files_with_output(
+				&file_fixes.changed_files,
+				cargo_options,
+				verbose,
+				progress,
+			)?;
+
+		if semantic::semantic_check_succeeded(&final_stdout) != Some(true) {
+			return Err(eyre::eyre!(
+				"vstyle tune: [{scope_label}] final semantic validation failed after fixer recovery."
+			));
+		}
+	}
+
+	Ok(semantic_applied)
+}
+
+fn run_fix_round(
+	files: &[PathBuf],
+	cargo_options: &CargoOptions,
+	verbose: bool,
+	progress: bool,
+) -> Result<FixRoundSummary> {
+	let scope_label = fix_scope_label(cargo_options);
+
+	if progress {
+		eprintln!("vstyle tune: [{scope_label}] collecting fixes for {} file(s).", files.len());
+	}
+
+	let round_start_snapshot = collect_file_snapshots(files);
+	let collected = collect_file_fixes(files, &scope_label, progress)?;
+
+	if collected.changed_files.is_empty() {
+		if progress {
+			eprintln!(
+				"vstyle tune: [{scope_label}] applied {} fix(es) this round.",
+				collected.total_applied
+			);
+		}
+
+		return Ok(FixRoundSummary::default());
+	}
+
+	let semantic_cargo_options =
+		scoped_semantic_cargo_options(cargo_options, &collected.changed_files)?;
+	let baseline_error_files = validate_pre_edit_semantic_baseline(
+		&collected.changed_files,
+		&semantic_cargo_options,
+		&scope_label,
+		verbose,
+		progress,
+	)?;
+	let mut file_fixes = apply_collected_file_fixes(collected)?;
+	let semantic_applied = apply_semantic_validation(
+		&scope_label,
+		&mut file_fixes,
+		&semantic_cargo_options,
+		&baseline_error_files,
+		verbose,
+		progress,
+	)?;
 	let net_changed_files = changed_files_since_snapshot(&round_start_snapshot);
 
 	// Count this round as no-op when all edits are eventually rolled back.
@@ -562,11 +673,11 @@ fn run_fix_round(
 	})
 }
 
-fn collect_and_apply_file_fixes(
+fn collect_file_fixes(
 	files: &[PathBuf],
 	scope_label: &str,
 	progress: bool,
-) -> Result<FileFixApplication> {
+) -> Result<CollectedFileFixes> {
 	let collect_started = Instant::now();
 	let type_alias_plan = collect_type_alias_rename_plan(files)?;
 	let outcomes_all = collect_fix_outcomes(files, &type_alias_plan, scope_label, progress)?;
@@ -582,16 +693,20 @@ fn collect_and_apply_file_fixes(
 		);
 	}
 
+	Ok(CollectedFileFixes { outcomes: outcomes_all, changed_files, total_applied })
+}
+
+fn apply_collected_file_fixes(collected: CollectedFileFixes) -> Result<FileFixApplication> {
 	let mut application = FileFixApplication {
-		changed_files,
-		total_applied,
+		changed_files: collected.changed_files,
+		total_applied: collected.total_applied,
 		import_fallbacks: BTreeMap::new(),
 		changed_originals: BTreeMap::new(),
 		let_mut_reorder_files: BTreeMap::new(),
 		type_alias_rename_files: BTreeMap::new(),
 	};
 
-	for outcome in outcomes_all {
+	for outcome in collected.outcomes {
 		apply_file_fix_outcome(outcome, &mut application)?;
 	}
 
@@ -702,6 +817,18 @@ fn collect_file_snapshots(files: &[PathBuf]) -> BTreeMap<PathBuf, String> {
 	}
 
 	snapshots
+}
+
+fn restore_file_snapshots(snapshots: &BTreeMap<PathBuf, String>) -> Result<()> {
+	for (path, original) in snapshots {
+		if fs::read_to_string(path).is_ok_and(|current| current == *original) {
+			continue;
+		}
+
+		fs::write(path, original)?;
+	}
+
+	Ok(())
 }
 
 fn changed_files_since_snapshot(snapshots: &BTreeMap<PathBuf, String>) -> Vec<PathBuf> {
@@ -4376,6 +4503,44 @@ where
 	}
 
 	#[test]
+	fn import008_keeps_lowercase_ffi_type_function_collision_fully_qualified() {
+		let original = r#"
+fn install(signal: i32) {
+	let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+
+	unsafe {
+		libc::sigaction(signal, &raw const action, std::ptr::null_mut());
+	}
+}
+"#;
+		let path = Path::new("import008_lowercase_ffi_type_function_collision.rs");
+		let (rewritten, _applied_count, _had_import_shortening_edits, _had_let_mut_reorder_edits) =
+			crate::style::apply_fix_passes(path, original, true).expect("apply fix passes");
+
+		assert!(!rewritten.contains("use libc::sigaction;"), "{rewritten}");
+		assert!(rewritten.contains("action: libc::sigaction"), "{rewritten}");
+		assert!(rewritten.contains("libc::sigaction(signal"), "{rewritten}");
+
+		let ctx = shared::read_file_context_from_text(path, rewritten.clone())
+			.expect("context")
+			.expect("has ctx");
+		let (violations, edits) = crate::style::collect_violations(&ctx, true);
+
+		assert!(!violations.iter().any(|violation| {
+			matches!(violation.rule, "RUST-STYLE-IMPORT-008" | "RUST-STYLE-IMPORT-009")
+		}));
+		assert!(!edits.iter().any(|edit| {
+			matches!(edit.rule, "RUST-STYLE-IMPORT-008" | "RUST-STYLE-IMPORT-009")
+		}));
+
+		let (repeated, applied_count, _, _) =
+			crate::style::apply_fix_passes(path, &rewritten, true).expect("repeat fix passes");
+
+		assert_eq!(applied_count, 0);
+		assert_eq!(repeated, rewritten);
+	}
+
+	#[test]
 	fn import008_merges_alias_child_import_into_existing_parent_module_use() {
 		let original = r#"
 use futures::channel::mpsc;
@@ -4711,6 +4876,44 @@ pub fn run() -> std::result::Result<(), String> {
 
 		assert!(!violations.iter().any(|v| v.rule == "RUST-STYLE-IMPORT-008"));
 		assert!(!edits.iter().any(|e| e.rule == "RUST-STYLE-IMPORT-008"));
+	}
+
+	#[test]
+	fn import008_keeps_io_result_qualified_when_unqualified_result_is_used() {
+		let text = r#"
+fn business_result() -> Result<(), i32> {
+	Ok(())
+}
+
+fn read_state() -> std::io::Result<String> {
+	Ok(String::new())
+}
+
+fn apply_test_override() -> Result<(), i32> {
+	Ok(())
+}
+"#;
+		let path = Path::new("import008_io_result_prelude_conflict.rs");
+		let ctx = shared::read_file_context_from_text(path, text.to_owned())
+			.expect("context")
+			.expect("has ctx");
+		let (violations, edits) = crate::style::collect_violations(&ctx, true);
+
+		assert!(!violations.iter().any(|violation| violation.rule == "RUST-STYLE-IMPORT-008"));
+		assert!(!edits.iter().any(|edit| edit.rule == "RUST-STYLE-IMPORT-008"));
+
+		let (rewritten, _, _, _) =
+			crate::style::apply_fix_passes(path, text, true).expect("apply fix passes");
+
+		assert!(!rewritten.contains("use std::io::Result;"), "Rewritten:\n{rewritten}");
+		assert!(
+			rewritten.contains("fn read_state() -> std::io::Result<String>"),
+			"Rewritten:\n{rewritten}"
+		);
+		assert!(
+			rewritten.contains("fn apply_test_override() -> Result<(), i32>"),
+			"Rewritten:\n{rewritten}"
+		);
 	}
 
 	#[test]
@@ -6892,6 +7095,46 @@ fn sample() {
 
 		assert!(applied >= 1);
 		assert!(rewritten.contains("let a = 1;\n\n\tif a > 0 {"));
+	}
+
+	#[test]
+	fn space003_does_not_split_if_condition_from_body_brace_after_block_expression() {
+		let text = r#"
+fn lane_reference(
+	metadata_file_type_is_symlink: bool,
+	metadata_is_regular_file: bool,
+	metadata_hard_link_count: u64,
+	metadata_owner_uid: u32,
+) -> bool {
+	if metadata_file_type_is_symlink
+		|| !metadata_is_regular_file
+		|| metadata_hard_link_count != 1
+		|| metadata_owner_uid != unsafe { libc::geteuid() }
+	{
+		return false;
+	}
+
+	true
+}
+"#;
+		let path = Path::new("space_if_condition_block_expression.rs");
+		let ctx = shared::read_file_context_from_text(path, text.to_owned())
+			.expect("context")
+			.expect("has ctx");
+		let (violations, edits) = crate::style::collect_violations(&ctx, true);
+
+		assert!(!violations.iter().any(|violation| {
+			violation.rule == "RUST-STYLE-SPACE-003"
+				&& violation.message
+					== "Insert exactly one blank line between different statement types."
+		}));
+		assert!(!edits.iter().any(|edit| edit.rule == "RUST-STYLE-SPACE-003"));
+
+		let (rewritten, applied_count, _, _) =
+			crate::style::apply_fix_passes(path, text, true).expect("apply fix passes");
+
+		assert_eq!(applied_count, 0);
+		assert_eq!(rewritten, text);
 	}
 
 	#[test]

--- a/src/style/bindings.rs
+++ b/src/style/bindings.rs
@@ -83,14 +83,18 @@ fn let_stmt_is_mut_ident(let_stmt: &LetStmt) -> bool {
 }
 
 fn let_stmt_mut_ident_name(let_stmt: &LetStmt) -> Option<String> {
+	if !let_stmt_is_mut_ident(let_stmt) {
+		return None;
+	}
+
+	let_stmt_ident_name(let_stmt)
+}
+
+fn let_stmt_ident_name(let_stmt: &LetStmt) -> Option<String> {
 	let pat = let_stmt.pat()?;
 
 	match pat {
-		ast::Pat::IdentPat(ident_pat) => {
-			ident_pat.mut_token()?;
-
-			Some(ident_pat.name()?.text().to_string())
-		},
+		ast::Pat::IdentPat(ident_pat) => Some(ident_pat.name()?.text().to_string()),
 		_ => None,
 	}
 }
@@ -198,6 +202,40 @@ fn let_stmt_by_value_unqualified_idents(let_stmt: &LetStmt) -> BTreeSet<String> 
 	out
 }
 
+fn let_stmt_initializer_is_reorder_safe(let_stmt: &LetStmt) -> bool {
+	let_stmt.let_else().is_none() && matches!(let_stmt.initializer(), Some(ast::Expr::Literal(_)))
+}
+
+fn run_preserves_initializer_order_semantics(run: &[LetStmtInfo]) -> bool {
+	let mut binding_names = BTreeSet::<String>::new();
+
+	for stmt in run {
+		if let Some(name) = let_stmt_ident_name(&stmt.stmt)
+			&& !binding_names.insert(name)
+		{
+			return false;
+		}
+	}
+	for (idx, stmt) in run.iter().enumerate() {
+		if !stmt.is_mut {
+			continue;
+		}
+
+		for later in &run[idx + 1..] {
+			if later.is_mut {
+				continue;
+			}
+			if !let_stmt_initializer_is_reorder_safe(&stmt.stmt)
+				|| !let_stmt_initializer_is_reorder_safe(&later.stmt)
+			{
+				return false;
+			}
+		}
+	}
+
+	true
+}
+
 fn run_is_reorderable_without_binding_errors(run: &[LetStmtInfo]) -> bool {
 	if run.len() <= 1 {
 		return false;
@@ -288,11 +326,15 @@ fn emit_run_fix(
 
 	if !run_is_reorderable_without_binding_errors(run) {
 		// The project convention is to only enforce this rule when the `let` bindings can be
-		// safely reordered. If not, treat it as compliant rather than emitting a violation.
+		// reordered without changing binding dependencies. Otherwise, treat the run as compliant.
 		return;
 	}
 
-	let can_edit = can_rewrite_run(ctx, run);
+	// Compiler validation cannot prove evaluation, failure, drop order, or shadowing equivalence.
+	// Report these runs, but only offer an edit when unique bindings with literal initializer pairs
+	// may cross.
+	let preserves_initializer_order = run_preserves_initializer_order_semantics(run);
+	let can_edit = preserves_initializer_order && can_rewrite_run(ctx, run);
 
 	shared::push_violation(violations, ctx, offending_line, RULE_ID, MESSAGE, can_edit);
 
@@ -430,5 +472,103 @@ fn demo(scored: Vec<u8>) -> usize {
 			super::RULE_ID
 		);
 		assert!(edits.iter().all(|e| e.rule != super::RULE_ID));
+	}
+
+	#[test]
+	fn side_effecting_initializers_are_not_reordered() {
+		let text = r#"
+fn record(events: &mut Vec<&'static str>, event: &'static str) -> usize {
+	events.push(event);
+
+	events.len()
+}
+
+fn demo(events: &mut Vec<&'static str>) {
+	let mut scratch = record(events, "scratch");
+	let marker = record(events, "marker");
+
+	scratch += marker;
+}
+"#;
+		let ctx = shared::read_file_context_from_text(
+			Path::new("let_initializer_side_effect_order.rs"),
+			text.to_owned(),
+		)
+		.expect("context")
+		.expect("has ctx");
+		let mut violations = Vec::new();
+		let mut edits = Vec::new();
+
+		bindings::check_let_mut_reorder(&ctx, &mut violations, &mut edits, true);
+
+		let violation = violations
+			.iter()
+			.find(|violation| violation.rule == super::RULE_ID)
+			.expect("report unsafe initializer order");
+
+		assert!(!violation.fixable);
+		assert!(edits.iter().all(|edit| edit.rule != super::RULE_ID));
+	}
+
+	#[test]
+	fn fallible_initializers_are_not_reordered() {
+		let text = r#"
+fn demo() -> Result<(), String> {
+	let mut scratch = create_scratch()?;
+	let marker = read_marker()?;
+
+	scratch.push_str(&marker);
+
+	Ok(())
+}
+"#;
+		let ctx = shared::read_file_context_from_text(
+			Path::new("let_initializer_failure_order.rs"),
+			text.to_owned(),
+		)
+		.expect("context")
+		.expect("has ctx");
+		let mut violations = Vec::new();
+		let mut edits = Vec::new();
+
+		bindings::check_let_mut_reorder(&ctx, &mut violations, &mut edits, true);
+
+		let violation = violations
+			.iter()
+			.find(|violation| violation.rule == super::RULE_ID)
+			.expect("report unsafe initializer order");
+
+		assert!(!violation.fixable);
+		assert!(edits.iter().all(|edit| edit.rule != super::RULE_ID));
+	}
+
+	#[test]
+	fn shadowed_literal_bindings_are_not_reordered() {
+		let text = r#"
+fn demo() -> usize {
+	let mut value = 1;
+	let value = 2;
+
+	value
+}
+"#;
+		let ctx = shared::read_file_context_from_text(
+			Path::new("let_initializer_shadowing.rs"),
+			text.to_owned(),
+		)
+		.expect("context")
+		.expect("has ctx");
+		let mut violations = Vec::new();
+		let mut edits = Vec::new();
+
+		bindings::check_let_mut_reorder(&ctx, &mut violations, &mut edits, true);
+
+		let violation = violations
+			.iter()
+			.find(|violation| violation.rule == super::RULE_ID)
+			.expect("report shadowing-sensitive reorder");
+
+		assert!(!violation.fixable);
+		assert!(edits.iter().all(|edit| edit.rule != super::RULE_ID));
 	}
 }

--- a/src/style/file.rs
+++ b/src/style/file.rs
@@ -432,7 +432,7 @@ fn unqualified_path_rewrites(
 			continue;
 		};
 
-		if !is_same_ident(name_ref.text().as_str(), symbol) {
+		if !is_same_ident(name_ref.text(), symbol) {
 			continue;
 		}
 
@@ -473,7 +473,7 @@ fn unqualified_macro_call_rewrites(
 			continue;
 		};
 
-		if !is_same_ident(name_ref.text().as_str(), symbol) {
+		if !is_same_ident(name_ref.text(), symbol) {
 			continue;
 		}
 

--- a/src/style/imports.rs
+++ b/src/style/imports.rs
@@ -402,7 +402,7 @@ fn import012_context_mentions_root(
 			continue;
 		};
 
-		if is_same_ident(name_ref.text().as_str(), normalized_root) {
+		if is_same_ident(name_ref.text(), normalized_root) {
 			return true;
 		}
 	}
@@ -473,6 +473,9 @@ fn build_import_analysis<'a>(
 	use_items: Vec<&'a TopItem>,
 ) -> ImportAnalysis<'a> {
 	let use_item_analyses = collect_use_item_analyses(ctx, &use_items);
+	let all_use_items =
+		ctx.top_items.iter().filter(|item| item.kind == TopKind::Use).collect::<Vec<_>>();
+	let all_use_item_analyses = collect_use_item_analyses(ctx, &all_use_items);
 	let use_item_analysis_by_key = use_item_analyses
 		.iter()
 		.enumerate()
@@ -480,7 +483,10 @@ fn build_import_analysis<'a>(
 		.collect::<HashMap<_, _>>();
 
 	ImportAnalysis {
-		imported_symbol_maps: collect_imported_symbol_maps(&use_item_analyses),
+		// A public re-export also introduces the symbol into the local module namespace. Keep
+		// public uses out of non-public grouping edits, but include them when deciding whether a
+		// qualified path already has an import.
+		imported_symbol_maps: collect_imported_symbol_maps(&all_use_item_analyses),
 		local_defined_symbols: collect_local_defined_symbols(ctx),
 		local_module_roots: collect_local_module_roots(ctx),
 		qualified_type_paths_by_symbol: collect_qualified_type_paths_by_symbol(ctx),
@@ -2327,7 +2333,7 @@ fn symbol_is_referenced_outside_use(ctx: &FileContext, symbol: &str) -> bool {
 			continue;
 		};
 
-		if is_same_ident(name_ref.text().as_str(), symbol) {
+		if is_same_ident(name_ref.text(), symbol) {
 			return true;
 		}
 	}
@@ -3282,6 +3288,7 @@ fn apply_import008_rules(
 		&analysis.imported_symbol_maps.full_paths_by_symbol,
 	);
 	let blocked_symbols = build_import008_blocked_symbols(
+		ctx,
 		&import008_candidates,
 		&analysis.imported_symbol_maps.full_paths_by_symbol,
 		&analysis.local_defined_symbols,
@@ -3331,14 +3338,17 @@ fn apply_import008_rules(
 }
 
 fn build_import008_blocked_symbols(
+	ctx: &FileContext,
 	import008_candidates: &[Import008Candidate],
 	imported_full_paths_by_symbol: &HashMap<String, HashSet<String>>,
 	local_defined_symbols: &HashSet<String>,
 	qualified_type_paths_by_symbol: &HashMap<String, HashSet<String>>,
 	qualified_value_paths_by_symbol: &HashMap<String, HashSet<String>>,
 ) -> HashSet<String> {
+	let unqualified_type_symbols = collect_unqualified_type_symbols(ctx);
 	let mut candidate_paths_by_symbol: HashMap<String, HashSet<String>> = HashMap::new();
 	let mut non_value_receiver_candidate_symbols = HashSet::new();
+	let mut type_candidate_paths_by_symbol: HashMap<String, HashSet<String>> = HashMap::new();
 
 	for candidate in import008_candidates {
 		candidate_paths_by_symbol
@@ -3346,6 +3356,12 @@ fn build_import008_blocked_symbols(
 			.or_default()
 			.insert(candidate.import_path.clone());
 
+		if candidate.kind == Import008CandidateKind::TypePath {
+			type_candidate_paths_by_symbol
+				.entry(candidate.symbol.clone())
+				.or_default()
+				.insert(candidate.import_path.clone());
+		}
 		if !matches!(
 			candidate.kind,
 			Import008CandidateKind::ValueReceiver | Import008CandidateKind::ValuePath
@@ -3357,7 +3373,10 @@ fn build_import008_blocked_symbols(
 	let mut blocked_symbols = HashSet::new();
 
 	for (symbol, candidate_paths) in &candidate_paths_by_symbol {
-		let mut all_paths = imported_full_paths_by_symbol.get(symbol).cloned().unwrap_or_default();
+		let imported_paths = imported_full_paths_by_symbol.get(symbol).cloned().unwrap_or_default();
+		let introduces_short_name =
+			candidate_paths.iter().any(|path| !imported_paths.contains(path));
+		let mut all_paths = imported_paths;
 
 		all_paths.extend(candidate_paths.iter().cloned());
 
@@ -3370,14 +3389,22 @@ fn build_import008_blocked_symbols(
 
 		let has_non_value_receiver_candidate =
 			non_value_receiver_candidate_symbols.contains(symbol);
-		let import009_consistency_conflict = has_non_value_receiver_candidate
-			&& is_import009_type_like_symbol(symbol)
-			&& qualified_value_paths_by_symbol.get(symbol).is_some_and(|value_paths| {
-				candidate_paths.iter().any(|path| value_paths.contains(path))
+		let has_explicit_type_value_role_collision =
+			type_candidate_paths_by_symbol.get(symbol).is_some_and(|type_paths| {
+				qualified_value_paths_by_symbol.get(symbol).is_some_and(|value_paths| {
+					type_paths.iter().any(|path| value_paths.contains(path))
+				})
 			});
+		let import009_consistency_conflict = has_explicit_type_value_role_collision
+			|| (has_non_value_receiver_candidate
+				&& is_import009_type_like_symbol(symbol)
+				&& qualified_value_paths_by_symbol.get(symbol).is_some_and(|value_paths| {
+					candidate_paths.iter().any(|path| value_paths.contains(path))
+				}));
 
 		if all_paths.len() > 1
 			|| local_defined_symbols.contains(symbol)
+			|| (introduces_short_name && unqualified_type_symbols.contains(symbol))
 			|| import009_consistency_conflict
 		{
 			blocked_symbols.insert(symbol.clone());
@@ -3385,6 +3412,20 @@ fn build_import008_blocked_symbols(
 	}
 
 	blocked_symbols
+}
+
+fn collect_unqualified_type_symbols(ctx: &FileContext) -> HashSet<String> {
+	ctx.source_file
+		.syntax()
+		.descendants()
+		.filter_map(PathType::cast)
+		.filter_map(|path_type| {
+			path_type.path().and_then(|path| {
+				classify_type_path_candidate(ctx, path, PathQualificationRequirement::Unqualified)
+			})
+		})
+		.map(|candidate| normalize_ident(candidate.name_ref.text()).to_owned())
+		.collect()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4739,7 +4780,7 @@ fn unqualified_type_path_rewrites(
 			continue;
 		};
 
-		if !is_same_ident(candidate.name_ref.text().as_str(), symbol) {
+		if !is_same_ident(candidate.name_ref.text(), symbol) {
 			continue;
 		}
 
@@ -4820,7 +4861,7 @@ fn alias_root_path_name_ref_rewrites(
 			continue;
 		};
 
-		if !is_same_ident(candidate.name_ref.text().as_str(), alias) {
+		if !is_same_ident(candidate.name_ref.text(), alias) {
 			continue;
 		}
 
@@ -4975,7 +5016,7 @@ fn unqualified_nongeneric_type_path_rewrites(
 			continue;
 		};
 
-		if !is_same_ident(candidate.name_ref.text().as_str(), symbol) {
+		if !is_same_ident(candidate.name_ref.text(), symbol) {
 			continue;
 		}
 		if !candidate.suffix.is_empty() {
@@ -5000,7 +5041,7 @@ fn has_unqualified_generic_type_path_use(ctx: &FileContext, symbol: &str) -> boo
 			continue;
 		};
 
-		if !is_same_ident(candidate.name_ref.text().as_str(), symbol) {
+		if !is_same_ident(candidate.name_ref.text(), symbol) {
 			continue;
 		}
 		if !candidate.suffix.is_empty() {
@@ -5030,7 +5071,7 @@ fn unqualified_value_path_rewrites(
 			continue;
 		};
 
-		if !is_same_ident(candidate.name_ref.text().as_str(), symbol) {
+		if !is_same_ident(candidate.name_ref.text(), symbol) {
 			continue;
 		}
 
@@ -5156,7 +5197,7 @@ fn unqualified_value_paths_are_record_only(ctx: &FileContext, symbol: &str) -> b
 			continue;
 		};
 
-		if !is_same_ident(candidate.name_ref.text().as_str(), symbol) {
+		if !is_same_ident(candidate.name_ref.text(), symbol) {
 			continue;
 		}
 
@@ -7064,7 +7105,7 @@ fn unqualified_function_call_ranges(ctx: &FileContext, symbol: &str) -> Vec<(usi
 			continue;
 		};
 
-		if !is_same_ident(name_ref.text().as_str(), symbol) {
+		if !is_same_ident(name_ref.text(), symbol) {
 			continue;
 		}
 
@@ -7164,7 +7205,7 @@ fn unqualified_macro_call_ranges(ctx: &FileContext, symbol: &str) -> Vec<(usize,
 			continue;
 		};
 
-		if !is_same_ident(name_ref.text().as_str(), symbol) {
+		if !is_same_ident(name_ref.text(), symbol) {
 			continue;
 		}
 

--- a/src/style/semantic.rs
+++ b/src/style/semantic.rs
@@ -87,13 +87,20 @@ pub(crate) fn collect_compiler_error_files_with_output(
 		return Ok((String::new(), BTreeSet::new()));
 	}
 
-	let style_files = files.iter().map(|path| normalize_path(path)).collect::<BTreeSet<_>>();
 	let stdout = run_semantic_cargo_check(cargo_options, files, verbose, progress)?;
-	let all = collect_compiler_error_files_from_output(&stdout);
-	let compiler_error_files =
-		all.into_iter().filter(|path| style_files.contains(path)).collect::<BTreeSet<_>>();
+	let compiler_error_files = collect_compiler_error_files_from_output(&stdout);
 
 	Ok((stdout, compiler_error_files))
+}
+
+pub(crate) fn semantic_check_succeeded(output: &str) -> Option<bool> {
+	output.lines().rev().find_map(|line| {
+		let value = serde_json::from_str::<Value>(line).ok()?;
+
+		(value.get("reason").and_then(Value::as_str) == Some("build-finished"))
+			.then(|| value.get("success").and_then(Value::as_bool))
+			.flatten()
+	})
 }
 
 pub(crate) fn collect_compiler_error_files(
@@ -174,12 +181,12 @@ fn run_semantic_cargo_check(
 
 	if let Some(cache_path) = cache_path.as_ref() {
 		match read_cached_semantic_output(cache_path, verbose) {
-			Some(stdout) => {
+			Some(stdout) if semantic_check_succeeded(&stdout).is_some() => {
 				record_cache_hit();
 
 				return Ok(stdout);
 			},
-			None => {
+			Some(_) | None => {
 				record_cache_miss();
 			},
 		}
@@ -202,6 +209,13 @@ fn run_semantic_cargo_check(
 		cmd.output().map_err(|err| eyre::eyre!("Failed to run semantic cargo check: {err}."))?;
 	let stdout = String::from_utf8(output.stdout)
 		.map_err(|err| eyre::eyre!("Failed to parse cargo check output: {err}."))?;
+
+	if semantic_check_succeeded(&stdout).is_none() {
+		return Err(eyre::eyre!(
+			"Semantic cargo check exited with status {} without a `build-finished` result.",
+			output.status
+		));
+	}
 
 	if let Some(cache_path) = cache_path {
 		write_cached_semantic_output(&cache_path, &stdout, verbose);
@@ -730,6 +744,16 @@ mod tests {
 				.flat_map(|suggestion| suggestion.imports.iter())
 				.any(|import| import == "use std::collections::HashMap;")
 		);
+	}
+
+	#[test]
+	fn reads_semantic_build_finished_status() {
+		let succeeded = r#"{"reason":"build-finished","success":true}"#;
+		let failed = r#"{"reason":"build-finished","success":false}"#;
+
+		assert_eq!(semantic::semantic_check_succeeded(succeeded), Some(true));
+		assert_eq!(semantic::semantic_check_succeeded(failed), Some(false));
+		assert_eq!(semantic::semantic_check_succeeded("not json"), None);
 	}
 
 	#[test]

--- a/src/style/spacing.rs
+++ b/src/style/spacing.rs
@@ -3,6 +3,7 @@ use std::{
 	sync::LazyLock,
 };
 
+use ra_ap_syntax::{AstNode, ast::IfExpr};
 use regex::Regex;
 
 use crate::style::{
@@ -122,13 +123,46 @@ impl StatementPair {
 	}
 }
 
+struct VerticalSpacingTraversal {
+	visited_blocks: HashSet<(usize, usize)>,
+	if_condition_body_boundaries: HashSet<(usize, usize)>,
+}
+impl VerticalSpacingTraversal {
+	fn new(ctx: &FileContext) -> Self {
+		let if_condition_body_boundaries = ctx
+			.source_file
+			.syntax()
+			.descendants()
+			.filter_map(IfExpr::cast)
+			.filter_map(|if_expr| {
+				let condition = if_expr.condition()?;
+				let then_branch = if_expr.then_branch()?;
+				let condition_end_offset =
+					usize::from(condition.syntax().text_range().end()).checked_sub(1)?;
+				let condition_end_line =
+					shared::line_from_offset(&ctx.line_starts, condition_end_offset)
+						.saturating_sub(1);
+				let body_start_line = shared::line_from_offset(
+					&ctx.line_starts,
+					usize::from(then_branch.syntax().text_range().start()),
+				)
+				.saturating_sub(1);
+
+				Some((condition_end_line, body_start_line))
+			})
+			.collect();
+
+		Self { visited_blocks: HashSet::new(), if_condition_body_boundaries }
+	}
+}
+
 pub(crate) fn check_vertical_spacing(
 	ctx: &FileContext,
 	violations: &mut Vec<Violation>,
 	edits: &mut Vec<Edit>,
 	emit_edits: bool,
 ) {
-	let mut visited_blocks: HashSet<(usize, usize)> = HashSet::new();
+	let mut traversal = VerticalSpacingTraversal::new(ctx);
 
 	for (start, end) in quality::function_ranges(ctx) {
 		check_vertical_spacing_block(
@@ -136,7 +170,7 @@ pub(crate) fn check_vertical_spacing(
 			violations,
 			edits,
 			emit_edits,
-			&mut visited_blocks,
+			&mut traversal,
 			start,
 			end,
 		);
@@ -148,15 +182,20 @@ fn check_vertical_spacing_block(
 	violations: &mut Vec<Violation>,
 	edits: &mut Vec<Edit>,
 	emit_edits: bool,
-	visited_blocks: &mut HashSet<(usize, usize)>,
+	traversal: &mut VerticalSpacingTraversal,
 	start: usize,
 	end: usize,
 ) {
-	if end <= start || !visited_blocks.insert((start, end)) {
+	if end <= start || !traversal.visited_blocks.insert((start, end)) {
 		return;
 	}
 
-	let statements = extract_top_level_statements(&ctx.lines, start, end);
+	let statements = extract_top_level_statements(
+		&ctx.lines,
+		&traversal.if_condition_body_boundaries,
+		start,
+		end,
+	);
 
 	if statements.is_empty() {
 		return;
@@ -185,7 +224,7 @@ fn check_vertical_spacing_block(
 		violations,
 		edits,
 		emit_edits,
-		visited_blocks,
+		traversal,
 		start,
 		end,
 		&statements,
@@ -444,7 +483,7 @@ fn recurse_spacing_child_blocks(
 	violations: &mut Vec<Violation>,
 	edits: &mut Vec<Edit>,
 	emit_edits: bool,
-	visited_blocks: &mut HashSet<(usize, usize)>,
+	traversal: &mut VerticalSpacingTraversal,
 	start: usize,
 	end: usize,
 	statements: &[StatementSpan],
@@ -465,7 +504,7 @@ fn recurse_spacing_child_blocks(
 				violations,
 				edits,
 				emit_edits,
-				visited_blocks,
+				traversal,
 				child_start,
 				child_end,
 			);
@@ -987,31 +1026,28 @@ fn classify_statement_type(statement_lines: &[String]) -> String {
 
 fn extract_top_level_statements(
 	lines: &[String],
+	if_condition_body_boundaries: &HashSet<(usize, usize)>,
 	fn_start: usize,
 	fn_end: usize,
 ) -> Vec<(usize, usize, String)> {
-	fn next_significant_line_starts_with_dot(
+	fn next_significant_line(
 		lines: &[String],
 		mut mask_state: CodeMaskState,
 		from_idx: usize,
 		fn_end: usize,
-	) -> bool {
-		for line in lines.iter().take(fn_end).skip(from_idx + 1) {
+	) -> Option<(usize, String)> {
+		for (idx, line) in lines.iter().enumerate().take(fn_end).skip(from_idx + 1) {
 			let code = mask_code_line(line, &mut mask_state);
 			let stripped = code.trim();
 
 			if stripped.is_empty() {
 				continue;
 			}
-			// Attributes apply to the next statement. Treat them as a hard boundary.
-			if stripped.starts_with('#') {
-				return false;
-			}
 
-			return stripped.starts_with('.');
+			return Some((idx, stripped.to_owned()));
 		}
 
-		false
+		None
 	}
 
 	let mut statements = Vec::new();
@@ -1052,13 +1088,20 @@ fn extract_top_level_statements(
 			continue;
 		};
 		let stripped_code = code.trim();
+		let next_significant = next_significant_line(lines, mask_state, idx, fn_end);
+		let continues_method_chain =
+			next_significant.as_ref().is_some_and(|(_, stripped)| stripped.starts_with('.'));
+		let continues_if_condition = next_significant
+			.as_ref()
+			.is_some_and(|(next_idx, _)| if_condition_body_boundaries.contains(&(idx, *next_idx)));
 		let statement_closed = brace_depth == 1
 			&& paren_depth == 0
 			&& bracket_depth == 0
 			&& !stripped_code.is_empty()
 			&& (stripped_code.ends_with(';')
 				|| (stripped_code.ends_with('}')
-					&& !next_significant_line_starts_with_dot(lines, mask_state, idx, fn_end)));
+					&& !continues_method_chain
+					&& !continues_if_condition));
 
 		if statement_closed {
 			let span_lines = lines[current_start_value..=idx].to_vec();

--- a/src/style/types.rs
+++ b/src/style/types.rs
@@ -95,7 +95,7 @@ pub(crate) fn build_type_alias_usage_rename_edits(
 		let Some(name_ref) = segment.name_ref() else {
 			continue;
 		};
-		let Some(replacement) = renames.get(name_ref.text().as_str()) else {
+		let Some(replacement) = renames.get(name_ref.text()) else {
 			continue;
 		};
 		let range = name_ref.syntax().text_range();

--- a/tests/let_mut_reorder.rs
+++ b/tests/let_mut_reorder.rs
@@ -37,6 +37,28 @@ fn main() {}
 	root
 }
 
+fn create_atomicity_crate_root() -> PathBuf {
+	let stamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("Clock.").as_nanos();
+	let root = env::temp_dir().join(format!("vstyle-tune-atomicity-{stamp}"));
+	let _ = fs::remove_dir_all(&root);
+
+	fs::create_dir_all(root.join("src")).expect("Create source directory.");
+	fs::write(
+		root.join("Cargo.toml"),
+		r#"
+[package]
+name = "vstyle-tune-atomicity-fixture"
+version = "0.1.0"
+edition = "2024"
+build = "build.rs"
+"#,
+	)
+	.expect("Write Cargo manifest.");
+	fs::write(root.join(".gitignore"), "/target\n").expect("Write gitignore.");
+
+	root
+}
+
 #[test]
 fn let_mut_reorder_is_semantically_validated_by_compiler() {
 	let temp_dir = create_temp_crate_root();
@@ -176,8 +198,8 @@ pub fn closure_carries_binding() {
 	);
 
 	assert!(
-		cold_output.contains("Semantic cache: 0 hit(s), 1 miss(es)."),
-		"expected one cold semantic miss, output: {cold_output}"
+		cold_output.contains("Semantic cache: 0 hit(s), 2 miss(es)."),
+		"expected cold pre-edit and post-edit semantic misses, output: {cold_output}"
 	);
 
 	fs::write(temp_dir.join("src/safe.rs"), safe_source).expect("restore safe source");
@@ -198,7 +220,168 @@ pub fn closure_carries_binding() {
 	);
 
 	assert!(
-		warm_output.contains("Semantic cache: 1 hit(s), 0 miss(es)."),
-		"expected one warm semantic hit, output: {warm_output}"
+		warm_output.contains("Semantic cache: 2 hit(s), 0 miss(es)."),
+		"expected warm pre-edit and post-edit semantic hits, output: {warm_output}"
 	);
+}
+
+#[test]
+fn tune_keeps_io_result_qualified_during_semantic_validation() {
+	let temp_dir = create_temp_crate_root();
+	let main_source = r#"fn business_result() -> Result<(), i32> {
+	Ok(())
+}
+
+fn read_state() -> std::io::Result<String> {
+	Ok(String::new())
+}
+
+fn apply_test_override() -> Result<(), i32> {
+	Ok(())
+}
+
+fn main() {
+	let value = 10f32;
+
+	println!("{value}");
+}
+"#;
+
+	fs::write(temp_dir.join("src/main.rs"), main_source).expect("Write main source.");
+
+	let output = Command::new("git")
+		.current_dir(&temp_dir)
+		.args(["init"])
+		.output()
+		.expect("Initialize Git repository.");
+
+	assert!(output.status.success());
+
+	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
+		.current_dir(&temp_dir)
+		.args(["tune", "--language", "rust", "--verbose"])
+		.output()
+		.expect("Run vstyle tune.");
+	let main_after = fs::read_to_string(temp_dir.join("src/main.rs")).expect("Read main source.");
+	let stderr = String::from_utf8_lossy(&output.stderr);
+
+	if !output.status.success() {
+		assert_eq!(main_after, main_source, "Failed tune did not roll back its edits.");
+	}
+
+	assert!(output.status.success(), "tune unexpectedly failed:\n{stderr}");
+	assert!(!main_after.contains("use std::io::Result;"));
+	assert!(main_after.contains("fn read_state() -> std::io::Result<String>"));
+	assert!(main_after.contains("fn apply_test_override() -> Result<(), i32>"));
+	assert!(main_after.contains("let value = 10_f32;"));
+	assert!(
+		stderr.contains("validating the edited files"),
+		"missing semantic validation telemetry:\n{stderr}"
+	);
+
+	let output = Command::new("cargo")
+		.current_dir(&temp_dir)
+		.arg("check")
+		.output()
+		.expect("Check tuned fixture.");
+
+	assert!(
+		output.status.success(),
+		"tuned fixture did not compile:\n{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
+		.current_dir(&temp_dir)
+		.args(["curate", "--language", "rust", "--strict"])
+		.output()
+		.expect("Run strict vstyle check.");
+
+	assert!(
+		output.status.success(),
+		"strict check failed:\n{}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+
+	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
+		.current_dir(&temp_dir)
+		.args(["tune", "--language", "rust", "--strict"])
+		.output()
+		.expect("Repeat vstyle tune.");
+	let repeated = fs::read_to_string(temp_dir.join("src/main.rs")).expect("Read tuned source.");
+
+	assert!(
+		output.status.success(),
+		"repeated tune failed:\n{}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert_eq!(repeated, main_after);
+
+	let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn tune_rolls_back_the_run_when_semantic_validation_fails() {
+	let temp_dir = create_atomicity_crate_root();
+	let main_source = r#"fn business_result() -> Result<(), i32> {
+	Ok(())
+}
+
+fn read_state() -> std::io::Result<String> {
+	Ok(String::new())
+}
+
+fn apply_test_override() -> Result<(), i32> {
+	Ok(())
+}
+
+fn main() {
+	let value = 10f32;
+
+	println!("{value}");
+}
+"#;
+	let build_source = r#"use std::fs;
+
+fn main() {
+	let _build_value = 20f32;
+
+	println!("cargo:rerun-if-changed=src/main.rs");
+
+	let source = fs::read_to_string("src/main.rs").unwrap_or_default();
+
+	if source.contains("10_f32") {
+		panic!("reject the edited fixture");
+	}
+}
+"#;
+
+	fs::write(temp_dir.join("src/main.rs"), main_source).expect("Write main source.");
+	fs::write(temp_dir.join("build.rs"), build_source).expect("Write build source.");
+
+	let output = Command::new("git")
+		.current_dir(&temp_dir)
+		.args(["init"])
+		.output()
+		.expect("Initialize Git repository.");
+
+	assert!(output.status.success());
+
+	let output = Command::new(env!("CARGO_BIN_EXE_vstyle"))
+		.current_dir(&temp_dir)
+		.args(["tune", "--language", "rust"])
+		.output()
+		.expect("Run vstyle tune.");
+	let main_after = fs::read_to_string(temp_dir.join("src/main.rs")).expect("Read main source.");
+	let build_after = fs::read_to_string(temp_dir.join("build.rs")).expect("Read build source.");
+	let stderr = String::from_utf8_lossy(&output.stderr);
+
+	assert!(!output.status.success(), "tune unexpectedly succeeded:\n{stderr}");
+	assert_eq!(main_after, main_source);
+	assert_eq!(build_after, build_source);
+	assert!(stderr.contains("semantic validation"), "missing semantic error:\n{stderr}");
+
+	let _ = fs::remove_dir_all(temp_dir);
 }


### PR DESCRIPTION
## Summary

- resolve import-role conflicts for lowercase FFI types/functions and `std::io::Result` shadowing
- preserve initializer evaluation order in LET-001 and roll back an entire tune run after semantic failure
- keep multiline `if` condition/body braces compatible with rustfmt
- roll direct dependencies and immutable GitHub Action pins
- consolidate shared Rust/TOML CI work and benchmark jobs without reducing validation coverage
- smoke-test each newly published GitHub Action asset before crates.io publication

## CI evidence

Baseline window: 2026-07-18T14:58:27Z through 2026-08-10T04:38:06Z.

- 82 runs / 112 jobs reconstructed to 171 provider-billed Linux minutes
- Language Checks used 80 minutes; the separate TOML job and repeated dev build were the dominant removable duplication
- historical replay estimates 39 minutes saved in Language Checks and about 7 minutes in Benchmarks (about 27% of total baseline minutes)
- cadence, dependency review, CodeQL, release targets, tests, and benchmark coverage are unchanged
- status: implemented, pending hosted measurement

## Validation

- `cargo make check` (534 tests)
- `cargo +nightly fmt --all -- --check`
- `taplo fmt --check`
- `actionlint`
- strict source-built `vstyle tune` (23 files, 0 findings, 0 edits)
- `cargo build --locked --profile final-release --all-features`
- clean-worktree `cargo package --locked`
- `cargo audit` (116 dependencies, 0 vulnerabilities/warnings)
- release and semantic benchmark suites at commit `9fe4d97`
