### PR TITLE
Release v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "vibe-style"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name        = "vibe-style"
 readme      = "README.md"
 repository  = "https://github.com/acgxv/vibe-style"
 resolver    = "3"
-version     = "0.2.3"
+version     = "0.2.4"
 
 [[bin]]
 name = "vstyle"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Use the composite action to install a prebuilt release and run a read-only style
 
 ```yaml
 - uses: actions/checkout@v6
-- uses: acgxv/vibe-style@v1
+- uses: acgxv/vibe-style@v0.2.4
   with:
     language: rust
     workspace: true
@@ -96,7 +96,7 @@ Use the composite action to install a prebuilt release and run a read-only style
 
 The action runs `vstyle curate --language <language>`, adds `--workspace` when
 `workspace: true`, and appends `args`. Use `language: swift` for Swift checks, and use
-`version: v0.2.3` when CI should pin a specific `vibe-style` release. Use
+`version: v0.2.4` when CI should pin a specific `vibe-style` release. Use
 `version: checkout` only when the workflow should build `vibe-style` from the action
 checkout, such as this repository's own local `uses: ./` workflow.
 


### PR DESCRIPTION
## Summary

- bump the crate and lockfile to v0.2.4
- pin the GitHub Action usage example and explicit action input to v0.2.4

## Validation

- `cargo make check` (534 tests)
- `actionlint`
- `cargo audit` (116 dependencies, 0 vulnerabilities/warnings)
- final-release binary: `vibe-style 0.2.4-f7b4b63-aarch64-apple-darwin`
- strict `vstyle tune`: 23 files, 0 findings, 0 edits
- release and semantic benchmark suites
- clean-worktree `cargo package --locked` (59 files; package verification compiled successfully)
