### PR TITLE
Make crates.io publishing recoverable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing signed release tag to publish on crates.io.
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +26,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name == 'push'
     name: Build ${{ matrix.target.name }} binary
     runs-on: ${{ matrix.target.os }}
     strategy:
@@ -125,10 +132,40 @@ jobs:
     name: Publish on crates.io
     runs-on: ubuntu-latest
     needs: [action-smoke]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      ((github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs['action-smoke'].result == 'success') ||
+      github.event_name == 'workflow_dispatch')
     steps:
+      - name: Require crates.io token
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: test -n "${CARGO_REGISTRY_TOKEN}"
+
       - name: Fetch latest code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - name: Verify recovery tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PUBLISH_TAG: ${{ inputs.tag }}
+        run: |
+          [[ "${PUBLISH_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          test "$(git cat-file -t "refs/tags/${PUBLISH_TAG}")" = tag
+          test "$(git rev-list -n 1 "refs/tags/${PUBLISH_TAG}")" = "$(git rev-parse HEAD)"
+
+      - name: Verify released GitHub Action for recovery
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./
+        with:
+          language: rust
+          workspace: true
+          args: --all-features
+          version: ${{ inputs.tag }}
 
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -137,4 +174,6 @@ jobs:
           components: rustfmt, clippy
 
       - name: Publish
-        run: cargo publish --locked --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked


### PR DESCRIPTION
## Summary

- fail before checkout/toolchain/package work when `CARGO_REGISTRY_TOKEN` is absent
- pass the token through Cargo's supported environment variable instead of the deprecated `--token` argument
- add a maintainer-only recovery dispatch for an existing strict-semver annotated tag
- require the recovery checkout to peel to the exact tag commit and rerun the released GitHub Action smoke before publishing
- preserve the normal tag path: build all targets → GitHub Release → action smoke → crates.io

## Evidence

The v0.2.4 release run reached crates.io publication only after package verification, then failed after 46 seconds because the token was empty: https://github.com/acg-box/vibe-style/actions/runs/31377153511

The recovery path checks out `refs/tags/<tag>` rather than a branch. Hosted checkout evidence from that run shows `refs/tags/v0.2.4` is retained as an annotated tag and peels to `ad5ea29`.

The OIDC alternative was not selected: the latest official auth action release bundles `undici 6.26.0`, and the current public audit reports unresolved runtime advisories. This PR introduces no new Action dependency.

## Validation

- `actionlint -verbose .github/workflows/release.yml`
- positive `v0.2.4` tag contract and negative `main` contract
- empty/non-empty token preflight contract
- `cargo make check` (534 tests passed)
- `cargo nextest run --workspace --all-targets --all-features --test-threads 4` (534 passed, no leaky tests)
- `cargo audit` (116 dependencies, 0 vulnerabilities/warnings)
