### PR TITLE
Keep crates.io recovery checkout clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,21 @@ jobs:
           args: --all-features
           version: ${{ inputs.tag }}
 
+      - name: Restore clean recovery checkout
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PUBLISH_TAG: ${{ inputs.tag }}
+        run: |
+          package="vibe-style-x86_64-unknown-linux-gnu-${PUBLISH_TAG}"
+          archive="${package}.tgz"
+
+          test -f "${archive}"
+          test -f "${package}/vstyle"
+          test -f "${package}/cargo-vstyle"
+          rm -- "${archive}" "${package}/vstyle" "${package}/cargo-vstyle"
+          rmdir -- "${package}"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:


### PR DESCRIPTION
## Summary

- remove the exact Linux release archive and extracted binaries created by the released-action recovery smoke
- require a completely clean checkout before `cargo publish`
- fail closed if the released action creates any unexpected artifact

## Root cause

Recovery run https://github.com/acg-box/vibe-style/actions/runs/31387235047 verified the tag and released action, then `cargo publish --locked` refused three untracked action artifacts. The token was accepted; this was checkout pollution, not an authentication failure.

## Validation

- `actionlint -verbose .github/workflows/release.yml`
- real `v0.2.4` Linux asset reproduction: 3 dirty entries before cleanup, clean checkout afterward
- `git diff --check origin/main...HEAD`
- signed commit verification