### PR TITLE
Avoid tag-scoped release caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache: true
+          # A later release tag cannot restore this tag-scoped build cache.
+          cache: false
           components: rustfmt, clippy
 
       - name: Add target


### PR DESCRIPTION
## Summary

- Stop saving release build caches that later version tags cannot restore.
- Keep the crates.io recovery cache and all release validation unchanged.

## Evidence

- The v0.2.4 build matrix missed all three caches and then stored 301,004,599 bytes.
- Cache export used about 20 runner-seconds across Linux, macOS, and Windows.
- `actionlint .github/workflows/*.yml`
- `git diff --check`

## Rollback

Set the release build cache input back to `true` if same-tag release reruns become a regular requirement.